### PR TITLE
feat:customred#FF5758とcustomblue'#174397'の色の記載をtailwind.config.jsに追加

### DIFF
--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -5,8 +5,23 @@ module.exports = {
     './app/assets/stylesheets/**/*.css',
     './app/javascript/**/*.js'
   ],
+  theme: {
+    extend: {
+      // Tailwind CSSのテーマカスタマイズ
+      colors: {
+        customblue: '#174397',
+        customred: "#FF5758",
+      },
+      spacing: {
+        '72': '18rem',           // カスタムの余白サイズの追加
+      },
+      borderRadius: {
+        'xl': '1.5rem',          // カスタムのボーダー半径
+      },
+    },
+  },
   plugins: [require("daisyui")],
   daisyui: {
-    darkTheme: false, // ダークモードをONにする場合は削除
+    themes: false,
   },
 }


### PR DESCRIPTION
## 概要
- `tailwind.config.js`にアプリで反映するカスタムを反映

```
      colors: {
        customblue: '#174397',
        customred: "#FF5758",
```

```
spacing: {
        '72': '18rem',           // カスタムの余白サイズの追加
      },
```

```
 borderRadius: {
        'xl': '1.5rem',          // カスタムのボーダー半径
      },
```

## 変更内容
- **修正**: tailwind.config.js`にアプリで反映するカスタムを反映


## 関連Issue
- #3 