### PR TITLE
feata:共通フッターの作成

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -21,5 +21,6 @@
     <%= render "shared/header" %>
     <%= yield %>
     <%= yield(:js) %>
+    <%= render "shared/footer" %>
   </body>
 </html>

--- a/app/views/shared/_error_messages.html.erb
+++ b/app/views/shared/_error_messages.html.erb
@@ -1,0 +1,10 @@
+<% if object.errors.any? %>
+  <div id="error-messages" class="alert alert-danger">
+    <h2><%= pluralize(object.errors.count, "エラー") %>が発生しました:</h2>
+    <ul>
+      <% object.errors.full_messages.each do |message| %>
+        <li><%= message %></li>
+      <% end %>
+    </ul>
+  </div>
+<% end %>

--- a/app/views/shared/_footer.html.erb
+++ b/app/views/shared/_footer.html.erb
@@ -1,0 +1,4 @@
+<footer class="bg-footer p-4 shadow mt-auto">
+    <%= render 'shared/footer_links' %>
+    <%= render 'shared/footer_copyright' %>
+</footer>

--- a/app/views/shared/_footer_copyright.html.erb
+++ b/app/views/shared/_footer_copyright.html.erb
@@ -1,0 +1,1 @@
+<p class="text-center text-gray-600 font-bold">© 2024 My-Song-Journal</p>

--- a/app/views/shared/_footer_links.html.erb
+++ b/app/views/shared/_footer_links.html.erb
@@ -1,0 +1,5 @@
+<div class="mt-4 flex justify-center space-x-6">
+  <a href="#" class="text-center text-gray-600 font-bold">お問い合わせ</a>
+  <a href="#" class="text-center text-gray-600 font-bold">プライバシーポリシー</a>
+  <a href="#" class="text-center text-gray-600 font-bold">利用規約</a>
+</div>

--- a/app/views/static_pages/_introduce.html.erb
+++ b/app/views/static_pages/_introduce.html.erb
@@ -1,6 +1,6 @@
 <div>
     <%= image_tag 'top.png' %>
-    <div class="bg-customblue text-customred font-bold py-7 px-4 rounded-full w-96 text-center text-4xl absolute top-[80%] left-[5rem] left-2">
+    <div class="bg-customblue text-customred font-bold py-7 px-4 rounded-full w-96 text-center text-4xl absolute top-[85%] left-[5rem] left-2">
         <p>日々の感情や思い出を音楽と一緒に<br>記録しませんか？</p>
     </div>
 </div>


### PR DESCRIPTION
## 概要
- フッター部分の新規作成とデザイン調整。
- エラーメッセージ表示用の共通コンポーネントを作成。
- トップページのデザイン微調整。

## 変更内容
- **新規追加**:
  - `app/views/shared/_footer.html.erb`: フッターのコンテナを作成。
  - `app/views/shared/_footer_links.html.erb`: フッター内のリンク部分を作成。
  - `app/views/shared/_footer_copyright.html.erb`: コピーライト部分を作成。
  - `app/views/shared/_error_messages.html.erb`: エラーメッセージを表示するコンポーネントを作成。
- **修正**:
  - `app/views/layouts/application.html.erb`:
    - フッターを全ページで表示するように追加。
  - `app/views/static_pages/_introduce.html.erb`:
    - トップページのテキスト位置を調整（`top-[80%]` → `top-[85%]`）。

## 動作確認方法
1. **フッターの表示確認**
   - [x] トップページにフッターが表示されていることを確認。
   - [x] フッター内のリンク（「お問い合わせ」「プライバシーポリシー」「利用規約」）が正しく表示されていることを確認。

## 関連Issue
<!-- 関連するIssue番号をリンク付きで記載 -->
- #5

## スクリーンショット（任意）

### フッターのスクリーンショット
![image](https://github.com/user-attachments/assets/c83cac64-da8e-4ae2-92cd-95b705a145a4)

## 備考
- フッター内リンクのURLは現在仮のリンク (`#`) になっています。本番環境で適切なリンクに変更が必要です。
- 今回の修正により、フッターのスタイルが全ページに影響を与える可能性があるため、デザイン確認を推奨します。

--- 