### PR TITLE
ログイン後topページの完成,logout機能の実装

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -2,9 +2,6 @@ class User < ApplicationRecord
   # Deviseのモジュール
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :validatable
-
   # バリデーション
   validates :name, presence: true, length: { maximum: 50 }
-  validates :email, presence: true, uniqueness: true, format: { with: URI::MailTo::EMAIL_REGEXP }
-  validates :password, presence: true, length: { minimum: 6 }, if: -> { new_record? || !password.nil? }
 end

--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -8,7 +8,9 @@
         </h2>
 
         <!-- Error Messages -->
-        <%= render "devise/shared/error_messages", resource: resource %>
+        <% if resource.errors.any? %>
+          <%= render "devise/shared/error_messages", resource: resource %>
+        <% end %>
 
         <!-- Name Field -->
         <div class="field">

--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -120,3 +120,16 @@
     <% end %>
   </div>
 </div>
+
+<script>
+  function togglePasswordVisibility(inputId, button) {
+    const input = document.getElementById(inputId);
+    if (input.type === "password") {
+      input.type = "text";
+      button.textContent = "🙈"; // Hide icon
+    } else {
+      input.type = "password";
+      button.textContent = "👁"; // Show icon
+    }
+  }
+</script>

--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -1,26 +1,79 @@
-<h2>Log in</h2>
+<div class="flex justify-center items-center bg-customblue">
+  <div class="rounded-lg p-8" style="aspect-ratio: 1 / 1; width: 90%; max-width: 400px;">
+    <%= render "devise/shared/form_layout" do %>
+      <form class="space-y-6 h-full" action="<%= session_path(resource_name) %>" method="post">
+        <!-- Title -->
+        <h2 class="text-2xl font-bold text-gray-700 text-center mb-6">
+          <%= t('devise.sessions.new.sign_in', default: 'ログイン') %>
+        </h2>
 
-<%= form_for(resource, as: resource_name, url: session_path(resource_name)) do |f| %>
-  <div class="field">
-    <%= f.label :email %><br />
-    <%= f.email_field :email, autofocus: true, autocomplete: "email" %>
+        <!-- Error Messages -->
+        <% if resource.errors.any? %>
+          <%= render "devise/shared/error_messages", resource: resource %>
+        <% end %>
+
+        <!-- Email Field -->
+        <div class="mb-4">
+          <label for="email" class="block text-gray-700 text-sm font-bold mb-2">
+            <%= t('activerecord.attributes.user.email', default: 'Eメール') %>
+          </label>
+          <input 
+            id="email" 
+            name="user[email]" 
+            type="email" 
+            placeholder="<%= t('activerecord.attributes.user.email', default: 'Eメール') %>" 
+            required 
+            autocomplete="email" 
+            class="shadow appearance-none border rounded w-full py-3 px-4 text-gray-700 leading-tight focus:outline-none focus:ring-2 focus:ring-blue-500 focus:shadow-outline bg-gray-50 placeholder-gray-400"
+            value="<%= resource.email if resource.present? %>">
+        </div>
+
+        <!-- Password Field -->
+        <div class="mb-4 relative">
+          <label for="password" class="block text-gray-700 text-sm font-bold mb-2">
+            <%= t('activerecord.attributes.user.password', default: 'パスワード') %>
+          </label>
+          <div class="relative">
+            <input 
+              id="password" 
+              name="user[password]" 
+              type="password" 
+              placeholder="<%= t('activerecord.attributes.user.password', default: 'パスワード') %>" 
+              required 
+              autocomplete="current-password" 
+              class="shadow appearance-none border rounded w-full py-3 px-4 text-gray-700 leading-tight focus:outline-none focus:ring-2 focus:ring-blue-500 focus:shadow-outline bg-gray-50 placeholder-gray-400">
+            <button 
+              type="button" 
+              class="absolute right-3 top-1/2 transform -translate-y-1/2 text-gray-500 hover:text-gray-700 focus:outline-none" 
+              onclick="togglePasswordVisibility('password', this)">
+              👁
+            </button>
+          </div>
+        </div>
+
+        <!-- Submit Button -->
+        <div class="flex items-center justify-between">
+          <button 
+            type="submit" 
+            class="bg-blue-500 hover:bg-blue-700 text-white font-bold py-3 px-6 rounded focus:outline-none focus:shadow-outline w-full">
+            <%= t('devise.sessions.new.sign_in', default: 'ログイン') %>
+          </button>
+        </div>
+        <%= render "devise/shared/links" %>
+      </form>
+    <% end %>
   </div>
+</div>
 
-  <div class="field">
-    <%= f.label :password %><br />
-    <%= f.password_field :password, autocomplete: "current-password" %>
-  </div>
-
-  <% if devise_mapping.rememberable? %>
-    <div class="field">
-      <%= f.check_box :remember_me %>
-      <%= f.label :remember_me %>
-    </div>
-  <% end %>
-
-  <div class="actions">
-    <%= f.submit "Log in" %>
-  </div>
-<% end %>
-
-<%= render "devise/shared/links" %>
+<script>
+  function togglePasswordVisibility(inputId, button) {
+    const input = document.getElementById(inputId);
+    if (input.type === "password") {
+      input.type = "text";
+      button.textContent = "🙈"; // Hide icon
+    } else {
+      input.type = "password";
+      button.textContent = "👁"; // Show icon
+    }
+  }
+</script>

--- a/app/views/devise/shared/_error_messages.html.erb
+++ b/app/views/devise/shared/_error_messages.html.erb
@@ -1,12 +1,11 @@
 <% if resource.errors.any? %>
-  <div id="error_explanation" data-turbo-cache="false">
-    <h2>
+  <div id="error_explanation" class="bg-red-100 border border-red-400 text-red-700 px-4 py-3 rounded relative my-4">
+    <h2 class="font-bold text-lg mb-2">
       <%= I18n.t("errors.messages.not_saved",
                  count: resource.errors.count,
-                 resource: resource.class.model_name.human.downcase)
-       %>
+                 resource: resource.class.model_name.human.downcase) %>
     </h2>
-    <ul>
+    <ul class="list-disc list-inside">
       <% resource.errors.full_messages.each do |message| %>
         <li><%= message %></li>
       <% end %>

--- a/app/views/devise/shared/_flash_messages.html.erb
+++ b/app/views/devise/shared/_flash_messages.html.erb
@@ -1,7 +1,7 @@
 <% if flash.present? %>
   <div class="space-y-4">
     <% flash.each do |key, message| %>
-      <div class="<%= key == 'notice' ? 'bg-green-100 text-green-800' : 'bg-red-100 text-red-800' %> px-4 py-3 rounded-lg shadow-md">
+      <div class="<%= key == 'notice' ? 'bg-green-100 text-green-400' : 'bg-red-100 text-red-800' %> px-4 py-3 rounded-lg shadow-md">
         <p class="font-medium"><%= message %></p>
       </div>
     <% end %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -19,6 +19,7 @@
 
   <body class="wrap">
     <%= render "shared/header" %>
+    <%= render "devise/shared/flash_messages" %> 
     <%= yield %>
     <%= yield(:js) %>
     <%= render "shared/footer" %>

--- a/app/views/shared/_header_nav.html.erb
+++ b/app/views/shared/_header_nav.html.erb
@@ -1,6 +1,13 @@
 <nav class="flex justify-around items-center space-x-8 text-lg">
   <%= link_to 'みんなの日記を覗きにいく', '#', class: 'text-center text-gray-600 font-bold' %>
-  <%= link_to 'ログイン', "#", class: 'text-center text-gray-600 font-bold' %>
-  <%= link_to '新規登録', new_user_registration_path, class: 'text-center text-gray-600 font-bold' %>
-  <%= link_to 'パスワード再発行', "#", class: 'text-center text-gray-600 font-bold' %>
+  <% if user_signed_in? %>
+    <div class="flex items-center space-x-8">
+        <%= link_to 'プロフィール', "#", class: 'text-gray-600 font-bold hover:text-blue-500' %>
+        <%= button_to 'サインアウト', destroy_user_session_path, method: :delete, data: { turbo_method: :delete }, class: 'text-gray-600 font-bold hover:text-red-500' %>
+    </div>
+  <% else %>
+    <%= link_to 'サインイン', new_user_session_path, class: 'text-center text-gray-600 font-bold' %>
+    <%= link_to 'サインアップ', new_user_registration_path, class: 'text-center text-gray-600 font-bold' %>
+    <%= link_to 'パスワード再発行', new_user_password_path, class: 'text-center text-gray-600 font-bold' %>
+  <% end %>
 </nav>

--- a/app/views/shared/_header_nav.html.erb
+++ b/app/views/shared/_header_nav.html.erb
@@ -3,10 +3,10 @@
   <% if user_signed_in? %>
     <div class="flex items-center space-x-8">
         <%= link_to 'プロフィール', "#", class: 'text-gray-600 font-bold hover:text-blue-500' %>
-        <%= button_to 'サインアウト', destroy_user_session_path, method: :delete, data: { turbo_method: :delete }, class: 'text-gray-600 font-bold hover:text-red-500' %>
+        <%= button_to 'ログアウト', destroy_user_session_path, method: :delete, data: { turbo_method: :delete }, class: 'text-gray-600 font-bold hover:text-red-500' %>
     </div>
   <% else %>
-    <%= link_to 'サインイン', new_user_session_path, class: 'text-center text-gray-600 font-bold' %>
+    <%= link_to 'ログイン', new_user_session_path, class: 'text-center text-gray-600 font-bold' %>
     <%= link_to 'サインアップ', new_user_registration_path, class: 'text-center text-gray-600 font-bold' %>
     <%= link_to 'パスワード再発行', new_user_password_path, class: 'text-center text-gray-600 font-bold' %>
   <% end %>

--- a/app/views/static_pages/_main_content.html.erb
+++ b/app/views/static_pages/_main_content.html.erb
@@ -1,0 +1,9 @@
+<div>
+    <%= image_tag 'top.png',class: "relative"  %>
+    <div class="bg-customblue text-customred font-bold py-8 px-4 rounded-full w-96 text-center text-4xl absolute top-[75%] left-[5rem] left-2">
+        <%= link_to "日記を書く".html_safe, "#" %>
+    </div>
+    <div class="bg-customblue text-customred font-bold py-8 px-4 rounded-full w-96 text-center text-4xl absolute top-[90%] left-[5rem] left-2">
+        <%= link_to "過去の日記一覧".html_safe, "#" %>
+    </div>
+</div>

--- a/app/views/static_pages/top.html.erb
+++ b/app/views/static_pages/top.html.erb
@@ -1,1 +1,5 @@
-<%= render "introduce" %>
+<% if user_signed_in? %>
+    <%= render "main_content" %> <!-- 新しく作成したメインコンテンツ部分 -->
+        <% else %>
+    <%= render "introduce" %>
+<%end%>


### PR DESCRIPTION
## 概要
- ユーザー登録時のエラーメッセージの改善とレイアウト修正。
- ログアウト機能を実装し、ログイン後のヘッダーを完成。
- フラッシュメッセージとエラーメッセージのデザインを反映。
- ログイン後のトップページの完成

## 変更内容
- **バリデーション修正**
  - `User` モデルから直接のバリデーションを削除（不要コードを整理）。
- **フォーム修正**
  - `app/views/devise/registrations/new.html.erb` にエラーメッセージ表示の条件追加。
- **エラーメッセージデザイン**
  - `app/views/devise/shared/_error_messages.html.erb` を修正し、デザインに合わせたスタイルを追加。
  - エラーメッセージに赤色背景とリスト形式を適用。
- **フラッシュメッセージ表示**
  - `app/views/layouts/application.html.erb` に `render "devise/shared/flash_messages"` を追加し、ヘッダー直下にフラッシュメッセージを表示。
- **ヘッダー修正**
  - ログイン状態によって表示内容を切り替え。
  - ログアウトボタンを追加し、スタイルにホバーエフェクトを適用。

```
 <%= button_to 'サインアウト', destroy_user_session_path, method: :delete, data: { turbo_method: :delete }, class: 'text-gray-600 font-bold hover:text-red-500' %>
```

## 動作確認方法
1. **新規ユーザー登録**
   - [x] 必須フィールドを空のまま登録しようとするとエラーメッセージが表示される。
   - [x] 正しい情報を入力すると正常に登録される。
2. **ログイン後のヘッダー**
   - [x] ユーザーがログインした状態で「プロフィール」リンクと「サインアウト」ボタンが表示される。
   - [x] サインアウトボタンをクリックすると正常にログアウトされる。
3. **フラッシュメッセージ確認**
   - [x] ログイン成功時、登録成功時にフラッシュメッセージが表示される。
4. **エラーメッセージ確認**
   - [x] バリデーションエラー時にエラーメッセージが赤色背景でリスト形式で表示される。

## 関連Issue
- #4 
- #11 
- #14 
- #59 

## スクリーンショット
### エラーメッセージ表示例
![image](https://github.com/user-attachments/assets/2b8b6630-c771-44ab-8e5a-f779a83ce64b)

### ログイン後トップページ
![image](https://github.com/user-attachments/assets/a835d18c-5f1c-4280-bb7c-7ed94e2bc683)


