### PR TITLE
render-build.shの記載を修正

### DIFF
--- a/bin/render-build.sh
+++ b/bin/render-build.sh
@@ -3,4 +3,4 @@ set -o errexit
 bundle install
 bundle exec rake assets:precompile
 bundle exec rake assets:clean
-bundle exec rake db:migrate
+DISABLE_DATABASE_ENVIRONMENT_CHECK=1 bundle exec rake db:migrate:reset


### PR DESCRIPTION
render-build.shの記載を下記のように変更

bundle exec rake db:migrate
DISABLE_DATABASE_ENVIRONMENT_CHECK=1 bundle exec rake db:migrate:reset


下記記事参照
[《Rails》renderでの本番環境でのマイグレーションの注意【初学者のオリアプ作成】](https://zenn.dev/d_miyabi/articles/0ce427f40d2306)