### PR TITLE
refix:render-build.shの修正

### DIFF
--- a/bin/render-build.sh
+++ b/bin/render-build.sh
@@ -3,4 +3,4 @@ set -o errexit
 bundle install
 bundle exec rake assets:precompile
 bundle exec rake assets:clean
-DISABLE_DATABASE_ENVIRONMENT_CHECK=1 bundle exec rake db:migrate:reset
+bundle exec rake db:migrate


### PR DESCRIPTION
refix:render-build.shを下記のようにもとに戻しました


DISABLE_DATABASE_ENVIRONMENT_CHECK=1 bundle exec rake db:migrate:reset
bundle exec rake db:migrate
