### PR TITLE
feat:日記フィルター機能実装

### DIFF
--- a/app/controllers/journals_controller.rb
+++ b/app/controllers/journals_controller.rb
@@ -6,9 +6,9 @@ class JournalsController < ApplicationController
   @emotion_filter = params[:emotion] # フィルター条件を取得
   @journals = if @emotion_filter.present?
                 Journal.where(emotion: @emotion_filter) # 絞り込み
-              else
+  else
                 Journal.all # すべて取得
-              end
+  end
   end
 
   def show

--- a/app/controllers/journals_controller.rb
+++ b/app/controllers/journals_controller.rb
@@ -2,9 +2,13 @@ class JournalsController < ApplicationController
   before_action :authenticate_user!, except: [ :show, :index ]
   before_action :set_journal, only: [ :show, :edit, :update, :destroy ]
   before_action :authorize_journal, only: [ :edit, :update, :destroy ]
-
   def index
-    @journals = Journal.all
+  @emotion_filter = params[:emotion] # フィルター条件を取得
+  @journals = if @emotion_filter.present?
+                Journal.where(emotion: @emotion_filter) # 絞り込み
+              else
+                Journal.all # すべて取得
+              end
   end
 
   def show
@@ -27,6 +31,7 @@ class JournalsController < ApplicationController
   end
 
   def edit
+    @journal = Journal.find(params[:id])
   end
 
   def update

--- a/app/views/journals/index.html.erb
+++ b/app/views/journals/index.html.erb
@@ -1,9 +1,17 @@
 <div class="min-h-screen bg-customblue text-black flex flex-col items-center pt-8 pb-8">
   <div class="bg-white p-6 rounded shadow-md w-full max-w-2xl">
-    <!-- ページタイトル -->
-   <h1 class="text-2xl font-bold text-center mb-6">
+    <!-- ページタイトルと絞り込み -->
+    <div class="flex justify-between items-center mb-6">
+      <h1 class="text-2xl font-bold">
         <%= "#{current_user.name}'s Journal" %>
-    </h1>
+      </h1>
+      <%= form_with url: journals_path, method: :get, local: true, class: "flex items-center space-x-2 text-white" do |f| %>
+        <%= f.select :emotion, Journal.emotions.keys.map { |key| [key.humanize, key] },
+                     { include_blank: "すべて" },
+                     { class: "px-4 py-2 border rounded-md" } %>
+        <%= f.submit "絞り込む", class: "px-4 py-2 bg-blue-500 text-white rounded-md hover:bg-blue-600" %>
+      <% end %>
+    </div>
 
     <!-- 一覧表示 -->
     <ul class="space-y-4">
@@ -18,14 +26,15 @@
           <div class="flex space-x-4 mt-2">
             <!-- 日記を見るリンク -->
             <%= link_to '日記を見る', journal_path(journal), class: "px-6 py-2 bg-gray-500 text-white font-medium rounded shadow-md hover:bg-gray-600" %>
-            <!-- 編集リンク (色変更) -->
+            <!-- 編集リンク -->
             <%= link_to "編集", edit_journal_path(journal), class: "px-6 py-2 bg-yellow-500 text-white font-medium rounded shadow-md hover:bg-yellow-600" %>
-            <!-- 削除ボタン (色変更) -->
+            <!-- 削除ボタン -->
             <%= button_to "削除", journal_path(journal), method: :delete, data: { confirm: "本当に削除しますか？" }, class: "px-6 py-2 bg-red-500 text-white font-medium rounded shadow-md hover:bg-red-600" %>
           </div>
         </li>
       <% end %>
     </ul>
+
     <!-- 日記作成ボタン -->
     <div class="flex justify-center mt-6">
       <%= link_to "新しい日記を作成", new_journal_path, class: "btn btn-primary w-full" %>


### PR DESCRIPTION
## 概要

- 日記一覧ページに感情を基準とした絞り込み機能を追加しました。
- ユーザーが特定の感情に基づいて日記を表示できるようにしました。

---

## 変更内容

1. **コントローラの変更**
   - `JournalsController#index` に感情による絞り込み処理を追加。
     - URLパラメータ（`params[:emotion]`）を利用して日記を絞り込みます。
     - 条件が指定されていない場合は、すべての日記を表示します。

   ```ruby
   def index
     @emotion_filter = params[:emotion]
     @journals = if @emotion_filter.present?
                   Journal.where(emotion: @emotion_filter)
                 else
                   Journal.all
                 end
   end
   ```

2. **ビューの変更**
   - 日記一覧ページ (`app/views/journals/index.html.erb`) に絞り込み用のセレクトボックスを追加。
     - ユーザーが感情を選択し、「絞り込む」ボタンを押すことで該当する日記のみが表示されます。

   ```erb
   <%= form_with url: journals_path, method: :get, local: true, class: "flex items-center space-x-2 text-white" do |f| %>
     <%= f.select :emotion, Journal.emotions.keys.map { |key| [key.humanize, key] },
                  { include_blank: "すべて" },
                  { class: "px-4 py-2 border rounded-md" } %>
     <%= f.submit "絞り込む", class: "px-4 py-2 bg-blue-500 text-white rounded-md hover:bg-blue-600" %>
   <% end %>
   ```

3. **デザイン調整**
   - タイトルの横に絞り込みフォームを配置し、ユーザーが利用しやすいよう調整しました。
   - セレクトボックスやボタンにスタイルを適用。

---

## 動作確認方法

1. **一覧表示**
   - 絞り込みを適用しない（全てを選択している）場合、すべての日記が表示される。
2. **絞り込み機能**
   - 感情（例: `happy`）を選択して「絞り込む」ボタンを押すと、該当する日記のみ表示される。
   - 「すべて」を選択すると、全ての日記が表示される。
3. **URLの確認**
   - 選択された感情がURLパラメータとして反映される（例: `/journals?emotion=happy`）。
4. **セレクトボックス**
   - 現在選択中の感情がセレクトボックスに反映されている。

---

## 関連Issue

- #27 

---

## スクリーンショット

### 一覧ページ
#### 絞り込みフォーム
![image](https://github.com/user-attachments/assets/e6277b14-433d-4c64-ae82-f8cf4579166f)
![image](https://github.com/user-attachments/assets/5a90f0dd-c465-428b-bc1c-e9841064d5f9)


---

## 参考資料

[enumを利用してcheck_boxを作成し絞り込み検索を行う](https://qiita.com/Shokichi_jp/items/b97d6c48f295a3d54a81)

---

## 備考

- **追加可能な機能**:
  - 本リリースでは作成日やタイトルなど、他の条件でも絞り込みを可能にする拡張を検討します。
---

