### PR TITLE
fix:作成していないページのリンクは非表示しました

### DIFF
--- a/app/views/shared/_header_nav.html.erb
+++ b/app/views/shared/_header_nav.html.erb
@@ -1,13 +1,13 @@
 <nav class="flex justify-around items-center space-x-8 text-lg">
-  <%= link_to 'みんなの日記を覗きにいく', '#', class: 'text-center text-gray-600 font-bold' %>
+  <%# <%= link_to 'みんなの日記を覗きにいく', '#', class: 'text-center text-gray-600 font-bold' %> %>
   <% if user_signed_in? %>
     <div class="flex items-center space-x-8">
-        <%= link_to 'プロフィール', "#", class: 'text-gray-600 font-bold hover:text-blue-500' %>
+        <%# <%= link_to 'プロフィール', "#", class: 'text-gray-600 font-bold hover:text-blue-500' %> %>
         <%= button_to 'ログアウト', destroy_user_session_path, method: :delete, data: { turbo_method: :delete }, class: 'text-gray-600 font-bold hover:text-red-500' %>
     </div>
   <% else %>
     <%= link_to 'ログイン', new_user_session_path, class: 'text-center text-gray-600 font-bold' %>
     <%= link_to 'サインアップ', new_user_registration_path, class: 'text-center text-gray-600 font-bold' %>
-    <%= link_to 'パスワード再発行', new_user_password_path, class: 'text-center text-gray-600 font-bold' %>
+    <%# <%= link_to 'パスワード再発行', new_user_password_path, class: 'text-center text-gray-600 font-bold' %> %>
   <% end %>
 </nav>


### PR DESCRIPTION
## 概要

- 作成していないページのリンクをコメントアウトして非表示にしました

## 変更内容
- **修正**: 作成していないページのリンクをコメントアウトして非表示にしました
- みんなの日記を覗きにいく
- プロフィール
- パスワード再発行



## 関連Issue
-  #220 
