### PR TITLE
feat/SpotifyTokenモデルを追加: バリデーションと基本メソッドを実装

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -38,6 +38,13 @@ gem "bootsnap", require: false
 gem "devise"
 gem "devise-i18n"
 gem "devise-i18n-views"
+gem "rest-client"
+
+gem "rspotify"
+gem "dotenv-rails"
+gem "redis"
+gem "sidekiq"
+gem "sidekiq-cron"
 
 group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -97,6 +97,9 @@ GEM
     concurrent-ruby (1.3.4)
     connection_pool (2.4.1)
     crass (1.0.6)
+    cronex (0.15.0)
+      tzinfo
+      unicode (>= 0.4.4.5)
     cssbundling-rails (1.4.1)
       railties (>= 6.0.0)
     date (3.4.1)
@@ -112,10 +115,29 @@ GEM
     devise-i18n (1.12.1)
       devise (>= 4.9.0)
     devise-i18n-views (0.3.7)
+    domain_name (0.6.20240107)
+    dotenv (3.1.7)
+    dotenv-rails (3.1.7)
+      dotenv (= 3.1.7)
+      railties (>= 6.1)
     drb (2.2.1)
     erubi (1.13.0)
+    et-orbi (1.2.11)
+      tzinfo
+    faraday (2.12.2)
+      faraday-net_http (>= 2.0, < 3.5)
+      json
+      logger
+    faraday-net_http (3.4.0)
+      net-http (>= 0.5.0)
+    fugit (1.11.1)
+      et-orbi (~> 1, >= 1.2.11)
+      raabro (~> 1.4)
     globalid (1.2.1)
       activesupport (>= 6.1)
+    hashie (5.0.0)
+    http-cookie (1.0.8)
+      domain_name (~> 0.5)
     i18n (1.14.6)
       concurrent-ruby (~> 1.0)
     io-console (0.8.0)
@@ -128,6 +150,8 @@ GEM
     jsbundling-rails (1.3.1)
       railties (>= 6.0.0)
     json (2.9.0)
+    jwt (2.9.3)
+      base64
     language_server-protocol (3.17.0.3)
     logger (1.6.2)
     loofah (2.23.1)
@@ -140,9 +164,17 @@ GEM
       net-smtp
     marcel (1.0.4)
     matrix (0.4.2)
+    mime-types (3.6.0)
+      logger
+      mime-types-data (~> 3.2015)
+    mime-types-data (3.2024.1203)
     mini_mime (1.1.5)
     minitest (5.25.4)
     msgpack (1.7.5)
+    multi_xml (0.7.1)
+      bigdecimal (~> 3.1)
+    net-http (0.6.0)
+      uri
     net-imap (0.5.1)
       date
       net-protocol
@@ -152,6 +184,7 @@ GEM
       timeout
     net-smtp (0.5.0)
       net-protocol
+    netrc (0.11.0)
     nio4r (2.7.4)
     nokogiri (1.16.8-aarch64-linux)
       racc (~> 1.4)
@@ -165,6 +198,20 @@ GEM
       racc (~> 1.4)
     nokogiri (1.16.8-x86_64-linux)
       racc (~> 1.4)
+    oauth2 (2.0.9)
+      faraday (>= 0.17.3, < 3.0)
+      jwt (>= 1.0, < 3.0)
+      multi_xml (~> 0.5)
+      rack (>= 1.2, < 4)
+      snaky_hash (~> 2.0)
+      version_gem (~> 1.1)
+    omniauth (2.1.2)
+      hashie (>= 3.4.6)
+      rack (>= 2.2.3)
+      rack-protection
+    omniauth-oauth2 (1.8.0)
+      oauth2 (>= 1.4, < 3)
+      omniauth (~> 2.0)
     orm_adapter (0.5.0)
     parallel (1.26.3)
     parser (3.3.6.0)
@@ -177,8 +224,13 @@ GEM
     public_suffix (6.0.1)
     puma (6.5.0)
       nio4r (~> 2.0)
+    raabro (1.4.0)
     racc (1.8.1)
     rack (3.1.8)
+    rack-protection (4.1.1)
+      base64 (>= 0.1.0)
+      logger (>= 1.6.0)
+      rack (>= 3.0.0, < 4)
     rack-session (2.0.0)
       rack (>= 3.0.0)
     rack-test (2.1.0)
@@ -218,13 +270,25 @@ GEM
     rake (13.2.1)
     rdoc (6.8.1)
       psych (>= 4.0.0)
+    redis (5.3.0)
+      redis-client (>= 0.22.0)
+    redis-client (0.23.0)
+      connection_pool
     regexp_parser (2.9.3)
     reline (0.5.12)
       io-console (~> 0.5)
     responders (3.1.1)
       actionpack (>= 5.2)
       railties (>= 5.2)
+    rest-client (2.0.2)
+      http-cookie (>= 1.0.2, < 2.0)
+      mime-types (>= 1.16, < 4.0)
+      netrc (~> 0.8)
     rexml (3.3.9)
+    rspotify (2.12.4)
+      addressable (~> 2.8.0)
+      omniauth-oauth2 (>= 1.6)
+      rest-client (~> 2.0.2)
     rubocop (1.69.1)
       json (~> 2.3)
       language_server-protocol (>= 3.17.0)
@@ -262,6 +326,19 @@ GEM
       rexml (~> 3.2, >= 3.2.5)
       rubyzip (>= 1.2.2, < 3.0)
       websocket (~> 1.0)
+    sidekiq (7.3.7)
+      connection_pool (>= 2.3.0)
+      logger
+      rack (>= 2.2.4)
+      redis-client (>= 0.22.2)
+    sidekiq-cron (2.0.1)
+      cronex (>= 0.13.0)
+      fugit (~> 1.8, >= 1.11.1)
+      globalid (>= 1.0.1)
+      sidekiq (>= 6.5.0)
+    snaky_hash (2.0.1)
+      hashie
+      version_gem (~> 1.1, >= 1.1.1)
     sprockets (4.2.1)
       concurrent-ruby (~> 1.0)
       rack (>= 2.2.4, < 4)
@@ -279,10 +356,13 @@ GEM
       railties (>= 6.0.0)
     tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
+    unicode (0.4.4.5)
     unicode-display_width (3.1.2)
       unicode-emoji (~> 4.0, >= 4.0.4)
     unicode-emoji (4.0.4)
+    uri (1.0.2)
     useragent (0.16.11)
+    version_gem (1.1.4)
     warden (1.2.9)
       rack (>= 2.0.9)
     web-console (4.2.1)
@@ -315,13 +395,19 @@ DEPENDENCIES
   devise
   devise-i18n
   devise-i18n-views
+  dotenv-rails
   jbuilder
   jsbundling-rails
   pg (~> 1.1)
   puma (>= 5.0)
   rails (~> 7.2.2)
+  redis
+  rest-client
+  rspotify
   rubocop-rails-omakase
   selenium-webdriver
+  sidekiq
+  sidekiq-cron
   sprockets-rails
   stimulus-rails
   turbo-rails

--- a/app/models/spotify_token.rb
+++ b/app/models/spotify_token.rb
@@ -1,0 +1,65 @@
+require "rest-client"
+require "json"
+
+class SpotifyToken < ApplicationRecord
+  belongs_to :user
+
+  # バリデーション
+  validates :access_token, presence: true, length: { minimum: 50 }
+  validates :refresh_token, presence: true, length: { minimum: 50 }
+  validates :expires_at, presence: true
+
+  # トークンが期限切れかどうかを確認
+  def expired?
+    expires_at.nil? || Time.current >= expires_at
+  end
+
+  # アクセストークンを更新するメソッド
+  def refresh_access_token
+    response = RestClient.post(
+      "https://accounts.spotify.com/api/token",
+      {
+        grant_type: "refresh_token",
+        refresh_token: refresh_token
+      },
+      {
+        Authorization: "Basic #{Base64.strict_encode64("#{ENV['SPOTIFY_CLIENT_ID']}:#{ENV['SPOTIFY_CLIENT_SECRET']}")}",
+        content_type: "application/x-www-form-urlencoded"
+      }
+    )
+
+    data = JSON.parse(response.body)
+
+    update!(
+      access_token: data["access_token"],
+      expires_at: Time.current + data["expires_in"].to_i.seconds
+    )
+
+    Rails.logger.info "✅ アクセストークンが正常にリフレッシュされました。"
+  rescue RestClient::ExceptionWithResponse => e
+    Rails.logger.error "❌ Spotify API Error: #{e.response}"
+    raise "Failed to refresh access token"
+  rescue StandardError => e
+    Rails.logger.error "❌ 予期しないエラー: #{e.message}"
+    raise
+  end
+
+  # アクセストークンが無効であればリフレッシュ
+  def ensure_valid_token
+    refresh_access_token if expired?
+  end
+
+  # 全てのトークンをリフレッシュ
+  def self.refresh_all_tokens
+    SpotifyToken.find_each do |token|
+      next unless token.expired?
+
+      Rails.logger.info "🔄 トークンをリフレッシュ中: User ID #{token.user_id}"
+      token.refresh_access_token
+    rescue StandardError => e
+      Rails.logger.error "❌ User ID #{token.user_id} のトークンリフレッシュ中にエラーが発生しました: #{e.message}"
+    end
+  rescue StandardError => e
+    Rails.logger.error "❌ トークンの一括リフレッシュ中にエラーが発生しました: #{e.message}"
+  end
+end


### PR DESCRIPTION
## **概要**  
- Spotify APIトークンを管理・リフレッシュするための`SpotifyToken`モデルを新規追加  

---

## **変更内容**  
- **新規追加**: `SpotifyToken`モデル (`app/models/spotify_token.rb`)  
- **機能追加**: トークンの有効期限確認およびリフレッシュ機能  
- **機能追加**: 全ユーザーのトークンを一括リフレッシュ機能  
- **エラーハンドリング**: APIエラー時のログ出力と例外処理  

**主なメソッド:**  
- `expired?`：トークンの有効期限確認  
- `refresh_access_token`：アクセストークンのリフレッシュ  
- `ensure_valid_token`：無効なトークンの自動リフレッシュ  
- `self.refresh_all_tokens`：全トークンを一括リフレッシュ  

---

## **動作確認方法**  
1. **Spotify API認証情報設定**  
   - `.env`ファイルに以下の項目を追加  
   ```env
   SPOTIFY_CLIENT_ID=your_client_id
   SPOTIFY_CLIENT_SECRET=your_client_secret
   ```
2. **SpotifyTokenレコード作成**  
   ```ruby
   SpotifyToken.create!(
     user: User.first,
     access_token: "sample_access_token",
     refresh_token: "sample_refresh_token",
     expires_at: 10.minutes.from_now
   )
   ```
3. **トークン有効期限確認**  
   ```ruby
   SpotifyToken.first.expired?
   ```
4. **トークンリフレッシュ**  
   ```ruby
   SpotifyToken.first.refresh_access_token
   ```
5. **全トークンリフレッシュ**  
   ```ruby
   SpotifyToken.refresh_all_tokens
   ```
6. **ログ確認**  
   - Railsのログに正常なリフレッシュメッセージが表示されること  
---

## **参考資料**  
- [【Spotify Web API】アクセストークンの取得と更新（リフレッシュ）](https://takagi.blog/get-and-refresh-access-tokens-for-the-spotify-web-api/)  
