### PR TITLE
feat/SpotifyToken用マイグレーションを追加

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -38,6 +38,13 @@ gem "bootsnap", require: false
 gem "devise"
 gem "devise-i18n"
 gem "devise-i18n-views"
+gem "rest-client"
+
+gem "rspotify"
+gem "dotenv-rails"
+gem "redis"
+gem "sidekiq"
+gem "sidekiq-cron"
 
 group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem

--- a/db/migrate/20241220065731_create_spotify_tokens.rb
+++ b/db/migrate/20241220065731_create_spotify_tokens.rb
@@ -1,0 +1,13 @@
+class CreateSpotifyTokens < ActiveRecord::Migration[7.2]
+  def change
+    create_table :spotify_tokens do |t|
+      t.references :user, null: false, foreign_key: true # ユーザーとの関連
+      t.string :access_token
+      t.string :refresh_token
+      t.datetime :expires_at
+
+      t.timestamps
+    end
+    add_index :spotify_tokens, :refresh_token, unique: true
+  end
+end


### PR DESCRIPTION
### **概要**
Spotify認証用のトークンを保存するための`spotify_tokens`テーブルを作成。

---

### **変更内容**
- `spotify_tokens`テーブルを作成。
- 各カラムの追加：
   - `user_id`（ユーザー関連付け）
   - `access_token`（Spotifyアクセストークン）
   - `refresh_token`（Spotifyリフレッシュトークン）
   - `expires_at`（アクセストークンの有効期限）
- `refresh_token`にユニークインデックスを追加。

**マイグレーション内容：**
```ruby
class CreateSpotifyTokens < ActiveRecord::Migration[7.2]
  def change
    create_table :spotify_tokens do |t|
      t.references :user, null: false, foreign_key: true
      t.string :access_token
      t.string :refresh_token
      t.datetime :expires_at

      t.timestamps
    end
    add_index :spotify_tokens, :refresh_token, unique: true
  end
end
```

---

### **動作確認方法**
1. マイグレーションを実行：
   ```bash
   bin/rails db:migrate
   ```
2. `spotify_tokens`テーブルが作成されていることを確認：
   ```sql
   SELECT * FROM spotify_tokens;
   ```
3. 適切なカラムとインデックスが存在することを確認。