### PR TITLE
Feat/spotify init

### DIFF
--- a/config/initializers/rspotify.rb
+++ b/config/initializers/rspotify.rb
@@ -1,0 +1,2 @@
+require "rspotify"
+RSpotify.authenticate(ENV["SPOTIFY_CLIENT_ID"], ENV["SPOTIFY_CLIENT_SECRET"])

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2024_12_07_120425) do
+ActiveRecord::Schema[7.2].define(version: 2024_12_20_065731) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -28,18 +28,30 @@ ActiveRecord::Schema[7.2].define(version: 2024_12_07_120425) do
     t.index ["user_id"], name: "index_journals_on_user_id"
   end
 
+  create_table "spotify_tokens", force: :cascade do |t|
+    t.bigint "user_id", null: false
+    t.string "access_token"
+    t.string "refresh_token"
+    t.datetime "expires_at"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["refresh_token"], name: "index_spotify_tokens_on_refresh_token", unique: true
+    t.index ["user_id"], name: "index_spotify_tokens_on_user_id"
+  end
+
   create_table "users", force: :cascade do |t|
     t.string "email", default: "", null: false
     t.string "encrypted_password", default: "", null: false
+    t.string "name", default: "", null: false
     t.string "reset_password_token"
     t.datetime "reset_password_sent_at"
     t.datetime "remember_created_at"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.string "name", default: "", null: false
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end
 
   add_foreign_key "journals", "users"
+  add_foreign_key "spotify_tokens", "users"
 end


### PR DESCRIPTION
### **概要**  
Spotify APIと連携するため、`RSpotify`の初期化設定を追加し、Spotifyトークン管理用のスキーマを反映しました。

---

### **変更内容**  
- **新規追加:**  
   - `config/initializers/rspotify.rb`: Spotify API認証の初期化処理を追加。  
- **データベーススキーマ変更:**  
   - `db/schema.rb`に`spotify_tokens`テーブルを追加。  
   - `spotify_tokens`には`user_id`, `access_token`, `refresh_token`, `expires_at`カラムを追加。  
   - `refresh_token`にユニークインデックスを設定。  
- **マイグレーション適用:**  
   - バージョン `2024_12_20_065731` が適用済み。  

---

### **動作確認方法**  
1. **環境変数設定:**  
   - 以下の環境変数を設定：  
     ```bash
     export SPOTIFY_CLIENT_ID='your_spotify_client_id'
     export SPOTIFY_CLIENT_SECRET='your_spotify_client_secret'
     ```  
2. **Railsコンソールで認証確認:**  
   ```ruby
   require "rspotify"
   RSpotify.authenticate(ENV["SPOTIFY_CLIENT_ID"], ENV["SPOTIFY_CLIENT_SECRET"])
   ```  
3. **Spotify API接続確認:**  
   ```ruby
   RSpotify::User.find('username')
   ```  
4. **データベース確認:**  
   - `spotify_tokens`テーブルが存在し、正しいカラムが設定されていることを確認。  
---

### **備考**  
- Spotify APIの認証情報は環境変数経由で管理されているため、`dotenv-rails`などで安全に取り扱うことを推奨。  
- `schema.rb`が最新状態であることを確認済み。

---