### PR TITLE
feat/sidekiq周り

### DIFF
--- a/app/workers/spotify_token_refresh_worker.rb
+++ b/app/workers/spotify_token_refresh_worker.rb
@@ -1,0 +1,9 @@
+class SpotifyTokenRefreshWorker
+  include Sidekiq::Worker
+
+  def perform
+    Rails.logger.info "🔄 Sidekiq: Spotifyトークンの定期リフレッシュを開始"
+    SpotifyToken.refresh_all_tokens
+    Rails.logger.info "✅ Sidekiq: Spotifyトークンの定期リフレッシュが完了"
+  end
+end

--- a/config/application.rb
+++ b/config/application.rb
@@ -24,5 +24,6 @@ module Myapp
     # config.time_zone = "Central Time (US & Canada)"
     # config.eager_load_paths << Rails.root.join("extras")
     config.i18n.default_locale = :ja
+    config.active_job.queue_adapter = :sidekiq
   end
 end

--- a/config/initializers/sidekiq.rb
+++ b/config/initializers/sidekiq.rb
@@ -1,0 +1,7 @@
+Sidekiq.configure_server do |config|
+  config.redis = { url: ENV["REDIS_URL"] || "redis://redis:6379/0" }
+end
+
+Sidekiq.configure_client do |config|
+  config.redis = { url: ENV["REDIS_URL"] || "redis://redis:6379/0" }
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -7,6 +7,9 @@ Rails.application.routes.draw do
   get "up" => "rails/health#show", as: :rails_health_check
   resources :journals
 
+  require "sidekiq/web"
+  mount Sidekiq::Web => "/sidekiq"
+
   # Render dynamic PWA files from app/views/pwa/*
   get "service-worker" => "rails/pwa#service_worker", as: :pwa_service_worker
   get "manifest" => "rails/pwa#manifest", as: :pwa_manifest

--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -1,0 +1,12 @@
+:concurrency: 5
+:queues:
+  - default
+  - mailers
+  - critical
+
+:redis:
+  url: redis://redis:6379/0
+:schedule:
+  spotify_token_refresh:
+    cron: '0 * * * *' # 毎時0分に実行
+    class: 'SpotifyTokenRefreshWorker'


### PR DESCRIPTION
## 🚀 **概要**  
- Sidekiqの導入およびSpotifyトークンの自動リフレッシュ機能を実装  
- Sidekiq Webダッシュボードを追加  

---

## 🛠️ **変更内容**  
- **新規追加**: `SpotifyTokenRefreshWorker`クラスを追加 (`app/workers/spotify_token_refresh_worker.rb`)  
- **設定追加**: `config/application.rb` に `config.active_job.queue_adapter = :sidekiq` を追加  
- **初期化設定**: `config/initializers/sidekiq.rb` にSidekiqのRedis接続設定を追加  
- **ルート追加**: `config/routes.rb` にSidekiq Web UI (`/sidekiq`) を追加  
- **YAML設定**: `config/sidekiq.yml` にキューおよびスケジュール設定を追加  

---

## ✅ **動作確認方法**  
1. **Sidekiq Web UIへのアクセス**  
   - [ ] `/sidekiq` にアクセスし、UIが表示されることを確認  
2. **Spotifyトークンリフレッシュ**  
   - [ ] Sidekiq経由で `SpotifyTokenRefreshWorker` が定期実行されることを確認  
3. **Redis接続確認**  
   - [ ] Redisに正しく接続されていることを確認  

---


## 📚 **参考資料**  
- [[Sidekiq公式ドキュメント](https://github.com/mperham/sidekiq)](https://github.com/mperham/sidekiq)  
- [[Redis公式ドキュメント](https://redis.io/)](https://redis.io/)  

---

## 💬 **備考**  
- 本番環境のRedis接続確認が必要  
- Spotify APIの認証エラーハンドリングも要確認  

---