### PR TITLE
Docker Compose調整

### DIFF
--- a/compose.yml
+++ b/compose.yml
@@ -1,3 +1,5 @@
+version: '3.8' # Docker Composeのバージョンを指定
+
 services:
   db:
     image: postgres
@@ -6,7 +8,7 @@ services:
       TZ: Asia/Tokyo
       POSTGRES_PASSWORD: password
     volumes:
-      - postgresql_data:/var/lib/postgresql
+      - postgres_volume:/var/lib/postgresql/data
     ports:
       - 5432:5432
     healthcheck:
@@ -14,6 +16,7 @@ services:
       interval: 10s
       timeout: 5s
       retries: 5
+
   web:
     build:
       context: .
@@ -27,12 +30,39 @@ services:
       - node_modules:/myapp/node_modules
     environment:
       TZ: Asia/Tokyo
+      REDIS_URL: redis://redis:6379/0
     ports:
       - "3000:3000"
     depends_on:
       db:
         condition: service_healthy
+
+  sidekiq:
+    container_name: sidekiq_container
+    build:
+      context: .
+      dockerfile: Dockerfile.dev
+    command: bundle exec sidekiq
+    volumes:
+      - .:/myapp
+      - bundle_data:/usr/local/bundle:cached
+    environment:
+      TZ: Asia/Tokyo
+      POSTGRES_PASSWORD: password
+    depends_on:
+      - db
+      - redis
+
+  redis:
+    image: "redis:7.0-alpine"
+    volumes:
+      - redis_volume:/data
+    command: redis-server --appendonly yes
+    ports:
+      - "6379:6379"
+
 volumes:
   bundle_data:
-  postgresql_data:
+  postgres_volume:
+  redis_volume:
   node_modules:


### PR DESCRIPTION
## 🚀 **概要**  
- Docker Composeを使用してRailsアプリケーション、Sidekiq、PostgreSQL、Redisの開発環境を構築しました。  
- サービス間の依存関係や永続化ボリュームの設定を追加し、安定した開発環境を提供します。  

---

## 🛠️ **変更内容**  

### **1. データベース (db) サービス**  
- `postgres` イメージを使用。  
- 永続化ボリューム `postgres_volume` を追加。  
- `healthcheck` によりPostgreSQLが正常に起動していることを確認。

### **2. Web (Rails) サービス**  
- `Dockerfile.dev` を使用してRailsアプリケーションを構築。  
- `bundle install`、`rails db:prepare` をコマンドに追加。  
- 開発環境用にポート `3000` を公開。  
- 永続化ボリューム `bundle_data`、`node_modules` を追加。  

### **3. Sidekiq サービス**  
- `bundle exec sidekiq` コマンドを使用。  
- `db` および `redis` サービスに依存。  
- 環境変数 `POSTGRES_PASSWORD` を設定。  

### **4. Redis サービス**  
- `redis:7.0-alpine` イメージを使用。  
- 永続化ボリューム `redis_volume` を追加。  
- ポート `6379` を公開。  

### **5. 永続化ボリューム**  
- データベース、Redis、Bundle、NodeModules のデータを永続化。  

---

## **変更後のdocker-compose.yml**

```yaml
version: '3.8'

services:
  db:
    image: postgres
    restart: always
    environment:
      TZ: Asia/Tokyo
      POSTGRES_PASSWORD: password
    volumes:
      - postgres_volume:/var/lib/postgresql/data
    ports:
      - 5432:5432
    healthcheck:
      test: ["CMD-SHELL", "pg_isready -d myapp_development -U postgres"]
      interval: 10s
      timeout: 5s
      retries: 5

  web:
    build:
      context: .
      dockerfile: Dockerfile.dev
    command: bash -c "bundle install && bundle exec rails db:prepare && rm -f tmp/pids/server.pid && ./bin/dev"
    tty: true
    stdin_open: true
    volumes:
      - .:/myapp
      - bundle_data:/usr/local/bundle:cached
      - node_modules:/myapp/node_modules
    environment:
      TZ: Asia/Tokyo
      REDIS_URL: redis://redis:6379/0
    ports:
      - "3000:3000"
    depends_on:
      db:
        condition: service_healthy

  sidekiq:
    container_name: sidekiq_container
    build:
      context: .
      dockerfile: Dockerfile.dev
    command: bundle exec sidekiq
    volumes:
      - .:/myapp
      - bundle_data:/usr/local/bundle:cached
    environment:
      TZ: Asia/Tokyo
      POSTGRES_PASSWORD: password
    depends_on:
      - db
      - redis

  redis:
    image: "redis:7.0-alpine"
    volumes:
      - redis_volume:/data
    command: redis-server --appendonly yes
    ports:
      - "6379:6379"

volumes:
  bundle_data:
  postgres_volume:
  redis_volume:
  node_modules:
```

---

## ✅ **動作確認方法**  

1. **コンテナの起動**  
   ```bash
   docker-compose up --build
   ```

2. **データベースの接続確認**  
   - [ ] `rails db:migrate` が正常に動作すること。  

3. **Railsアプリケーション確認**  
   - [ ] `http://localhost:3000` にアクセスしてアプリケーションが起動していること。  

4. **Sidekiq動作確認**  
   - [ ] `http://localhost:3000/sidekiq` からSidekiq UIが動作すること。  

5. **Redis接続確認**  
   - [ ] Redisが正常に接続され、ジョブがキューに追加されること。  

---