### PR TITLE
feat/モーダル作成

### DIFF
--- a/app/controllers/spotify_controller.rb
+++ b/app/controllers/spotify_controller.rb
@@ -1,0 +1,40 @@
+class SpotifyController < ApplicationController
+  def search
+    @tracks = []
+
+    if params[:query].present?
+      results = if params[:search_type] == "artist"
+                  RSpotify::Track.search("artist:#{params[:query]}")
+                elsif params[:search_type] == "track"
+                  RSpotify::Track.search("track:#{params[:query]}")
+                end
+
+      @tracks = results.map do |track|
+        {
+          song_name: track.name,
+          artist_name: track.artists.first.name,
+          preview_url: track.preview_url,
+          album_image: track.album.images.first["url"]
+        }
+      end
+    end
+
+    respond_to do |format|
+      format.html { render partial: 'spotify/search_form' }
+      format.turbo_stream { render partial: 'spotify/search_form' }
+    end
+  end
+
+  def select_tracks
+    return unless params[:selected_track].present?
+
+    begin
+      session[:selected_track] = JSON.parse(params[:selected_track])
+      flash[:notice] = "曲を保存しました。"
+      redirect_to new_journal_path
+    rescue JSON::ParserError => e
+      flash.now[:alert] = "曲の保存に失敗しました。エラー: #{e.message}"
+      render :search, status: :unprocessable_entity
+    end
+  end
+end

--- a/app/controllers/spotify_controller.rb
+++ b/app/controllers/spotify_controller.rb
@@ -1,40 +1,39 @@
 class SpotifyController < ApplicationController
+  # 曲を検索するアクション
   def search
     @tracks = []
 
     if params[:query].present?
-      results = if params[:search_type] == "artist"
-                  RSpotify::Track.search("artist:#{params[:query]}")
-                elsif params[:search_type] == "track"
-                  RSpotify::Track.search("track:#{params[:query]}")
-                end
+      begin
+        if params[:search_type] == "artist"
+          results = RSpotify::Track.search("artist:#{params[:query]}")
+        elsif params[:search_type] == "track"
+          results = RSpotify::Track.search("track:#{params[:query]}")
+        end
 
-      @tracks = results.map do |track|
-        {
-          song_name: track.name,
-          artist_name: track.artists.first.name,
-          preview_url: track.preview_url,
-          album_image: track.album.images.first["url"]
-        }
+        @tracks = results.map do |track|
+          {
+            song_name: track.name,
+            artist_name: track.artists.first&.name || "アーティスト不明",
+            preview_url: track.preview_url || "プレビューなし",
+            album_image: track.album&.images&.first&.fetch("url", "画像なし")
+          }
+        end
+      rescue RestClient::InternalServerError => e
+        Rails.logger.error "Spotify API Internal Server Error: #{e.message}"
+        flash.now[:alert] = "Spotify APIでエラーが発生しました。時間をおいて再度お試しください。"
+        @tracks = []
+      rescue StandardError => e
+        Rails.logger.error "Unexpected Error: #{e.message}"
+        flash.now[:alert] = "予期しないエラーが発生しました。"
+        @tracks = []
       end
     end
 
+    # 検索結果をモーダルで表示
     respond_to do |format|
-      format.html { render partial: 'spotify/search_form' }
-      format.turbo_stream { render partial: 'spotify/search_form' }
-    end
-  end
-
-  def select_tracks
-    return unless params[:selected_track].present?
-
-    begin
-      session[:selected_track] = JSON.parse(params[:selected_track])
-      flash[:notice] = "曲を保存しました。"
-      redirect_to new_journal_path
-    rescue JSON::ParserError => e
-      flash.now[:alert] = "曲の保存に失敗しました。エラー: #{e.message}"
-      render :search, status: :unprocessable_entity
+      format.html { render partial: "spotify/search_form" }
+      format.turbo_stream { render partial: "spotify/search_form" }
     end
   end
 end

--- a/app/javascript/application.js
+++ b/app/javascript/application.js
@@ -1,3 +1,4 @@
 // Entry point for the build script in your package.json
 import "@hotwired/turbo-rails"
 import "./controllers"
+import './modal';

--- a/app/javascript/modal.js
+++ b/app/javascript/modal.js
@@ -1,0 +1,29 @@
+document.addEventListener('DOMContentLoaded', () => {
+    const openModalButton = document.getElementById('open-search-modal');
+    const spotifyModal = document.getElementById('spotify-modal');
+    const modalContent = document.getElementById('spotify-modal-content');
+  
+    // モーダルを開く
+    openModalButton.addEventListener('click', () => {
+      spotifyModal.showModal();
+  
+      // 検索フォームを動的にロード
+      fetch('/spotify/search', {
+        headers: { 'X-Requested-With': 'XMLHttpRequest' }
+      })
+        .then(response => response.text())
+        .then(html => {
+          modalContent.innerHTML = html;
+        })
+        .catch(error => {
+          console.error('検索フォームの読み込み中にエラーが発生しました:', error);
+          modalContent.innerHTML = '<p class="text-red-500">検索フォームの読み込みに失敗しました。</p>';
+        });
+    });
+  
+    // モーダルを閉じたら内容をリセット
+    spotifyModal.addEventListener('close', () => {
+      modalContent.innerHTML = '';
+    });
+  });
+  

--- a/app/views/journals/new.html.erb
+++ b/app/views/journals/new.html.erb
@@ -1,62 +1,43 @@
-<div class="min-h-screen bg-customred flex flex-col items-center justify-center relative">
+<div class="min-h-screen bg-customred text-gray-500 flex flex-col items-center justify-center relative">
   <div class="bg-white p-4 rounded shadow-md w-full max-w-lg relative">
     <%= form_with(model: @journal, local: true, id: "journal-form", class: "w-full space-y-6") do |form| %>
 
-      <!-- タイトル入力 -->
-      <div class="form-control">
-        <%= form.label :title, "タイトル", class: "label text-sm" %>
-        <div id="title-container" class="w-3/4 mx-auto">
-          <!-- 表示状態 -->
-          <div id="title-display" class="hidden flex flex-col items-center justify-center">
-            <span id="title-text" class="text-xl font-bold text-center block">
-              <%= @journal.title.presence || "タイトル未設定" %>
-            </span>
-            <button type="button" id="edit-title-btn" class="btn btn-outline btn-xs mt-2">
-              編集
-            </button>
-          </div>
-          <!-- 編集状態 -->
-          <div id="title-edit" class="<%= @journal.title.present? ? 'hidden' : '' %>">
-            <%= form.text_field :title, required: true, placeholder: "タイトルを入力", class: "input input-bordered w-full text-sm" %>
-          </div>
-        </div>
+      <!-- 日付表示 -->
+      <div class="form-control text-2xl">
+        <span class="text-center text-2xl"><%= Time.current.strftime('%Y年%m月%d日') %></span>
       </div>
 
-      <!-- 日付表示 -->
-      <div class="form-control text-right">
-        <span class="text-xs text-gray-500"><%= Time.current.strftime('%Y年%m月%d日') %></span>
+      <!-- タイトル入力 -->
+      <div class="form-control">
+        <%= form.label :title, "タイトル", class: "label text-xl text-center" %>
+        <%= form.text_field :title, required: true, placeholder: "タイトルを入力", class: "input input-bordered w-full text-sm" %>
       </div>
 
       <!-- メモ入力 -->
       <div class="form-control">
-        <%= form.label :content, "一言メモ", class: "label text-sm" %>
+        <%= form.label :content, "一言メモ", class: "label text-xl text-center" %>
         <%= form.text_area :content, required: true, placeholder: "今日の出来事や気持ちを記入", class: "textarea textarea-bordered text-sm" %>
       </div>
 
       <!-- 感情入力 -->
       <div class="form-control">
-        <%= form.label :emotion, "感情", class: "label text-sm" %>
+        <%= form.label :emotion, "感情", class: "label text-xl text-center" %>
         <%= form.select :emotion, options_for_select([["喜", 0], ["怒", 1], ["哀", 2], ["楽", 3]], @journal.emotion), { prompt: "選択してください" }, class: "select select-bordered text-sm" %>
       </div>
 
-      <!-- 曲情報入力 -->
+      <!-- 検索ボタン（モーダルを開く） -->
       <div class="form-control">
-        <%= form.label :artist_name, "アーティスト名", class: "label text-sm" %>
-        <%= form.text_field :artist_name, required: true, placeholder: "アーティスト名を入力", class: "input input-bordered text-sm" %>
-      </div>
-
-      <div class="form-control">
-        <%= form.label :song_name, "曲名", class: "label text-sm" %>
-        <%= form.text_field :song_name, required: true, placeholder: "曲名を入力", class: "input input-bordered text-sm" %>
+        <button type="button" id="open-search-modal" class="btn btn-secondary w-full">
+          曲を選ぶ
+        </button>
       </div>
 
       <!-- 保存ボタン -->
       <div class="form-control">
         <%= form.submit "日記を保存", class: "btn btn-primary text-sm w-full" %>
       </div>
-
     <% end %>
   </div>
 </div>
 
-
+<%= render 'shared/spotify_modal' %>

--- a/app/views/shared/_spotify_modal.html.erb
+++ b/app/views/shared/_spotify_modal.html.erb
@@ -1,0 +1,8 @@
+<dialog id="spotify-modal" class="modal">
+  <div class="modal-box relative bg-customblue text-white">
+    <form method="dialog">
+      <button class="btn btn-sm btn-circle btn-ghost absolute right-2 top-2 text-white">✕</button>
+    </form>
+    <div id="spotify-modal-content" class="mt-4 text-white"></div>
+  </div>
+</dialog>

--- a/app/views/spotify/_search_form.html.erb
+++ b/app/views/spotify/_search_form.html.erb
@@ -1,0 +1,31 @@
+<!-- Spotify 検索フォーム -->
+<h2 class="text-lg font-bold mb-4 text-white">Spotify 曲検索</h2>
+
+<%= form_with url: spotify_search_path, method: :get, local: false, remote: true, id: "spotify-search-form" do |f| %>
+  <!-- 検索タイプ選択 -->
+  <div class="mb-4">
+    <%= f.label :search_type, "検索タイプ", class: "block text-sm font-medium text-white mb-2" %>
+    <%= f.select :search_type,
+          [["曲名で検索", "track"], ["アーティスト名で検索", "artist"]],
+          { prompt: "検索タイプを選択" },
+          { id: "search-type-select",
+            class: "mt-1 block w-full px-4 py-2 border border-gray-400 rounded-md shadow-sm text-white bg-gray-700 placeholder-white focus:ring-blue-500 focus:border-blue-500 appearance-none" } %>
+  </div>
+
+  <!-- 検索キーワード入力 -->
+  <div class="mb-4">
+    <%= f.label :query, "検索キーワード", class: "block text-sm font-medium text-white mb-2" %>
+    <%= f.text_field :query,
+          required: true,
+          id: "query-input",
+          class: "mt-1 block w-full px-4 py-2 border border-gray-400 rounded-md shadow-sm text-white bg-gray-700 placeholder-white focus:ring-blue-500 focus:border-blue-500" %>
+  </div>
+
+  <!-- 検索ボタン -->
+  <div class="text-center">
+    <%= f.submit "検索", class: "px-4 py-2 bg-blue-500 text-white font-medium rounded shadow-md hover:bg-blue-600" %>
+  </div>
+<% end %>
+
+<!-- 検索結果表示エリア -->
+<div id="search-results" class="mt-4 text-white"></div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -14,6 +14,9 @@ Rails.application.routes.draw do
   get "service-worker" => "rails/pwa#service_worker", as: :pwa_service_worker
   get "manifest" => "rails/pwa#manifest", as: :pwa_manifest
 
+  get "spotify/search", to: "spotify#search", as: :spotify_search
+  post "spotify/select_tracks", to: "spotify#select_tracks", as: :select_tracks
+
   # Defines the root path route ("/")
   root "static_pages#top"
 end


### PR DESCRIPTION
## 概要  
- **Spotify検索フォームをモーダルで実装**  
- **検索キーワードと検索タイプを入力し、検索ボタンでSpotify APIを呼び出せるように修正**  

---

## 変更内容  
- **新規追加**: Spotify検索用モーダルを`shared/_spotify_modal.html.erb`として作成  
- **新規追加**: JavaScriptでモーダル動作およびSpotify API連携処理を追加 (`app/javascript/modal.js`)  
- **修正**: `journals/new.html.erb`にモーダルを呼び出すボタンを追加  
- **追加**: `spotify#search` アクションを追加し、検索結果を返す処理を実装  
- **ルーティング**: `spotify/search`ルートを追加  

---

## 動作確認方法    
1. **モーダル表示確認**  
   - [ ] 「曲を選ぶ」ボタンをクリックするとSpotify検索モーダルが表示される  
2. **検索動作確認**  
   - [ ] 検索キーワードを入力し、検索ボタンをクリックするとSpotifyから検索結果が返る  (まだ、結果は帰ってこないです。次のプルリクで反映されるようにしたいです)
3. **未対応事項**  
   - [ ] **検索結果をモーダル内に表示する**（未実装）  
   - [ ] **検索結果から曲を選択し、フォームに反映する**（未実装）  

---

## 関連Issue  
<!-- 関連するIssue番号をリンク付きで記載 -->  
- #111   

---

## スクリーンショット（任意）  
- **モーダル表示**:  
   
![image](https://github.com/user-attachments/assets/504fca48-8058-4c4c-abef-1e1321a349c6)
 
- **検索フォーム（まだ未実装）**:  
   ![image](https://github.com/user-attachments/assets/b04b5a83-3cac-4a2b-b256-8a0ad8b0523e)