### PR TITLE
検索タイプか検索キーワードが入力されていない時、検索されないように設定

### DIFF
--- a/app/javascript/controllers/spotify_search.js
+++ b/app/javascript/controllers/spotify_search.js
@@ -5,10 +5,14 @@ export function initializeSearchConditions() {
   const searchConditionsContainer = document.getElementById('search-conditions');
   const addConditionBtn = document.getElementById('add-condition-btn');
   const removeConditionBtn = document.getElementById('remove-condition-btn');
+  const searchForm = document.getElementById('spotify-search-form');
+  const initialSearchType = document.getElementById('initial-search-type');
+  const initialQuery = document.getElementById('initial-query');
+
   let conditionId = 0; // 初期条件は非表示なので0から開始
   const MAX_CONDITIONS = 3; // 初期条件 + 追加2つ
 
-  if (!searchConditionsContainer || !addConditionBtn || !removeConditionBtn) {
+  if (!searchConditionsContainer || !addConditionBtn || !removeConditionBtn || !searchForm || !initialSearchType || !initialQuery) {
     console.warn('⚠️ 検索条件関連の要素が見つかりません。');
     return;
   }
@@ -67,11 +71,31 @@ export function initializeSearchConditions() {
     removeConditionBtn.setAttribute('data-listener', 'true');
   }
 
+  // ✅ 検索バリデーション
+  searchForm.addEventListener('submit', (event) => {
+    const errors = [];
+
+    // 初期条件のバリデーション
+    if (!initialSearchType.value.trim()) {
+      errors.push('⚠️ 検索タイプが選択されていません。');
+    }
+    if (!initialQuery.value.trim()) {
+      errors.push('⚠️ 検索キーワードが入力されていません。');
+    }
+
+    // エラー表示と送信ブロック
+    if (errors.length > 0) {
+      event.preventDefault(); // ページ遷移をブロック
+      alert(errors.join('\n'));
+      console.warn('❌ 検索バリデーションエラー:', errors);
+    }
+  });
+
   // 初期状態を設定
   updateButtonStates();
 }
 
-// ✅ 初期化関数// ✅ 初期化関数
+// ✅ 初期化関数
 function initializeSpotifySearch() {
   initializeSearchConditions();
 }


### PR DESCRIPTION
## 概要
- **検索条件のバリデーション強化**: 検索フォームにおいて、必要な条件が選択されていない場合にエラーメッセージを表示するバリデーションを追加。

## 変更内容
- **修正**: 検索条件が不足している場合にエラーを表示するようにバリデーションを追加。
- **修正**: 検索条件の追加・削除に関するコードを整理し、動的な検索条件追加が機能するように改善。

## 動作確認方法
1. **検索条件追加**
   - [ ] 検索条件を3つまで追加できる。
2. **検索バリデーション**
   - [ ] 必要な検索条件が選択されていない場合、エラーメッセージが表示され、フォーム送信が停止する。
3. **検索フォーム**
   - [ ] 入力フィールドが適切に動作し、正しい条件での検索が行える。
