### PR TITLE
Feat/search year

### DIFF
--- a/app/controllers/spotify_controller.rb
+++ b/app/controllers/spotify_controller.rb
@@ -96,6 +96,10 @@ class SpotifyController < ApplicationController
     end
   end
 
+  def year_search_template
+    render partial: "spotify/year_search_template"
+  end
+
   private
 
   # 🎤 アーティスト名を日本語で取得

--- a/app/javascript/application.js
+++ b/app/javascript/application.js
@@ -1,9 +1,15 @@
 // Entry point for the build script in your package.json
-import "@hotwired/turbo-rails"
-import "./controllers"
+import "@hotwired/turbo-rails";
+import "./controllers";
 import "./controllers/modal";
-import "./controllers/spotify_search";
+import { initializeSearchConditions } from "./controllers/spotify_search";
+import { initializeYearToggle } from "./controllers/spotify_year_toggle";
 
-document.addEventListener('turbo:load', initializeButtonsAndModal);
-document.addEventListener('turbo:render', initializeButtonsAndModal);
-document.addEventListener('DOMContentLoaded', initializeButtonsAndModal);
+function initializeSpotifySearch() {
+  initializeSearchConditions();
+  initializeYearToggle();
+}
+
+document.addEventListener('turbo:load', initializeSpotifySearch);
+document.addEventListener('turbo:render', initializeSpotifySearch);
+document.addEventListener('DOMContentLoaded', initializeSpotifySearch);

--- a/app/javascript/controllers/modal.js
+++ b/app/javascript/controllers/modal.js
@@ -16,10 +16,20 @@ function openSpotifyModal() {
     })
     .then(html => {
       modalContent.innerHTML = html;
-      // 動的インポートで関数を読み込み、実行
+
+      // 検索条件初期化
       import('./spotify_search.js')
         .then(module => {
-          module.initializeSearchConditions(); // 読み込んだ関数を実行
+          module.initializeSearchConditions();
+        })
+        .catch(error => {
+          console.error('モジュールの読み込みに失敗しました:', error);
+        });
+
+      // 年代トグル初期化
+      import('./spotify_year_toggle.js')
+        .then(module => {
+          module.initializeYearToggle();
         })
         .catch(error => {
           console.error('モジュールの読み込みに失敗しました:', error);

--- a/app/javascript/controllers/spotify_search.js
+++ b/app/javascript/controllers/spotify_search.js
@@ -7,43 +7,43 @@ export function initializeSearchConditions() {
   const removeConditionBtn = document.getElementById('remove-condition-btn');
   const searchForm = document.getElementById('spotify-search-form');
   let conditionId = 0; // 条件IDのカウンター
-  const MAX_CONDITIONS = 3; // 初期条件 + 追加2つ
+  const MAX_CONDITIONS = 2; // 初期条件 + 追加2つ
 
   if (!searchConditionsContainer || !addConditionBtn || !removeConditionBtn || !searchForm) {
     console.warn('⚠️ 検索条件関連の要素が見つかりません。');
     return;
   }
 
-
   // ✅ conditionId を動的に再計算する関数
   function getNextConditionId() {
     const conditions = searchConditionsContainer.querySelectorAll('.search-condition');
-    let maxId = 0;
-    conditions.forEach(condition => {
-      const id = parseInt(condition.dataset.conditionId, 10);
-      if (!isNaN(id) && id > maxId) {
-        maxId = id;
-      }
-    });
-    return maxId + 1;
+    const ids = Array.from(conditions).map((condition) => parseInt(condition.dataset.conditionId, 10) || 0);
+    return Math.max(0, ...ids) + 1;
   }
 
   // ✅ 検索条件テンプレート
-  const conditionTemplate = (id) => `
+  const conditionTemplate = (id, searchType = '', queryValue = '') => `
     <div class="search-condition mt-4" data-condition-id="${id}">
       <div class="mb-4">
         <label class="block text-sm font-medium text-white mb-2">🔍 検索タイプ</label>
         <select name="search_conditions[]" class="condition-select block w-full px-4 py-2 border rounded-md text-white bg-gray-700" data-condition-id="${id}">
           <option value="">検索タイプを選択</option>
-          <option value="track">曲名</option>
-          <option value="artist">アーティスト名</option>
-          <option value="keyword">キーワード</option>
-          <option value="year">年代</option>
+          <option value="track" ${searchType === 'track' ? 'selected' : ''}>曲名</option>
+          <option value="artist" ${searchType === 'artist' ? 'selected' : ''}>アーティスト名</option>
+          <option value="keyword" ${searchType === 'keyword' ? 'selected' : ''}>キーワード</option>
+          <option value="year" ${searchType === 'year' ? 'selected' : ''}>年代</option>
         </select>
       </div>
       <div class="mb-6" id="query-container-${id}">
-        <input type="text" name="search_values[]" placeholder="キーワードを入力"
-          class="condition-input block w-full px-4 py-2 border rounded-md text-white bg-gray-700">
+        ${
+          searchType === 'year'
+            ? `<select name="search_values[]" class="condition-select block w-full px-4 py-2 border rounded-md text-white bg-gray-700">
+                <option value="">年代を選択</option>
+                ${Array.from({ length: 26 }, (_, i) => `<option value="${2000 + i}" ${queryValue === String(2000 + i) ? 'selected' : ''}>${2000 + i}</option>`).join('')}
+              </select>`
+            : `<input type="text" name="search_values[]" value="${queryValue}" placeholder="キーワードを入力"
+                class="condition-input block w-full px-4 py-2 border rounded-md text-white bg-gray-700">`
+        }
       </div>
     </div>
   `;
@@ -58,7 +58,7 @@ export function initializeSearchConditions() {
 
   // ✅ 検索タイプ変更時の処理
   function attachConditionListeners(id) {
-    const searchType = document.querySelector(`[data-condition-id="${id}"]`);
+    const searchType = document.querySelector(`[data-condition-id="${id}"] .condition-select`);
     const queryContainer = document.getElementById(`query-container-${id}`);
 
     if (!searchType || !queryContainer) {
@@ -67,40 +67,35 @@ export function initializeSearchConditions() {
     }
 
     searchType.addEventListener('change', () => {
+      const currentQueryValue = queryContainer.querySelector('input, select')?.value || '';
       if (searchType.value === 'year') {
         queryContainer.innerHTML = `
           <select name="search_values[]" class="condition-select block w-full px-4 py-2 border rounded-md text-white bg-gray-700">
             <option value="">年代を選択</option>
-            ${Array.from({ length: 26 }, (_, i) => `<option value="${2000 + i}">${2000 + i}</option>`).join('')}
+            ${Array.from({ length: 26 }, (_, i) => `<option value="${2000 + i}" ${currentQueryValue === String(2000 + i) ? 'selected' : ''}>${2000 + i}</option>`).join('')}
           </select>
         `;
-        console.log(`🟢 検索フィールド ${id} が年代選択に切り替わりました`);
       } else {
         queryContainer.innerHTML = `
-          <input type="text" name="search_values[]" placeholder="キーワードを入力"
+          <input type="text" name="search_values[]" value="${currentQueryValue}" placeholder="キーワードを入力"
             class="condition-input block w-full px-4 py-2 border rounded-md text-white bg-gray-700">
         `;
-        console.log(`🟢 検索フィールド ${id} がテキスト入力に戻りました`);
       }
     });
   }
 
-// ✅ 検索条件追加 (重複イベントを防止)
-if (!addConditionBtn.dataset.listenerAdded) {
+  // ✅ 検索条件追加
   addConditionBtn.addEventListener('click', () => {
     if (searchConditionsContainer.querySelectorAll('.search-condition').length < MAX_CONDITIONS) {
-      conditionId += 1;
-      searchConditionsContainer.insertAdjacentHTML('beforeend', conditionTemplate(conditionId));
-      attachConditionListeners(conditionId);
+      const id = getNextConditionId();
+      searchConditionsContainer.insertAdjacentHTML('beforeend', conditionTemplate(id));
+      attachConditionListeners(id);
       updateButtonStates();
-      console.log(`🟢 検索条件${conditionId}が追加されました`);
+      console.log(`🟢 検索条件${id}が追加されました`);
     }
   });
-  addConditionBtn.dataset.listenerAdded = 'true';
-}
 
-// ✅ 検索条件削除 (重複イベントを防止)
-if (!removeConditionBtn.dataset.listenerAdded) {
+  // ✅ 検索条件削除
   removeConditionBtn.addEventListener('click', () => {
     const conditions = searchConditionsContainer.querySelectorAll('.search-condition');
     if (conditions.length > 1) {
@@ -109,14 +104,9 @@ if (!removeConditionBtn.dataset.listenerAdded) {
       console.log('🗑️ 最後の検索条件が削除されました。');
     }
   });
-  removeConditionBtn.dataset.listenerAdded = 'true';
-}
 
   // ✅ 初期条件にリスナーを適用
-  searchConditionsContainer.querySelectorAll('.search-condition').forEach((condition) => {
-    const id = condition.dataset.conditionId;
-    attachConditionListeners(id);
-  });
+  attachConditionListeners('initial');
 
   // ✅ 初期状態を設定
   updateButtonStates();

--- a/app/javascript/controllers/spotify_search.js
+++ b/app/javascript/controllers/spotify_search.js
@@ -6,15 +6,26 @@ export function initializeSearchConditions() {
   const addConditionBtn = document.getElementById('add-condition-btn');
   const removeConditionBtn = document.getElementById('remove-condition-btn');
   const searchForm = document.getElementById('spotify-search-form');
-  const initialSearchType = document.getElementById('initial-search-type');
-  const initialQuery = document.getElementById('initial-query');
+  let conditionId = 0; // 条件IDのカウンター
+  const MAX_CONDITIONS = 3; // 初期条件 + 追加2つ
 
-  let conditionId = 0;
-  const MAX_CONDITIONS = 3;
-
-  if (!searchConditionsContainer || !addConditionBtn || !removeConditionBtn || !searchForm || !initialSearchType || !initialQuery) {
+  if (!searchConditionsContainer || !addConditionBtn || !removeConditionBtn || !searchForm) {
     console.warn('⚠️ 検索条件関連の要素が見つかりません。');
     return;
+  }
+
+
+  // ✅ conditionId を動的に再計算する関数
+  function getNextConditionId() {
+    const conditions = searchConditionsContainer.querySelectorAll('.search-condition');
+    let maxId = 0;
+    conditions.forEach(condition => {
+      const id = parseInt(condition.dataset.conditionId, 10);
+      if (!isNaN(id) && id > maxId) {
+        maxId = id;
+      }
+    });
+    return maxId + 1;
   }
 
   // ✅ 検索条件テンプレート
@@ -22,7 +33,7 @@ export function initializeSearchConditions() {
     <div class="search-condition mt-4" data-condition-id="${id}">
       <div class="mb-4">
         <label class="block text-sm font-medium text-white mb-2">🔍 検索タイプ</label>
-        <select name="search_conditions[]" class="condition-select block w-full px-4 py-2 border rounded-md text-white bg-gray-700">
+        <select name="search_conditions[]" class="condition-select block w-full px-4 py-2 border rounded-md text-white bg-gray-700" data-condition-id="${id}">
           <option value="">検索タイプを選択</option>
           <option value="track">曲名</option>
           <option value="artist">アーティスト名</option>
@@ -30,8 +41,7 @@ export function initializeSearchConditions() {
           <option value="year">年代</option>
         </select>
       </div>
-      <div class="mb-6">
-        <label class="block text-sm font-medium text-white mb-2">📝 検索キーワード</label>
+      <div class="mb-6" id="query-container-${id}">
         <input type="text" name="search_values[]" placeholder="キーワードを入力"
           class="condition-input block w-full px-4 py-2 border rounded-md text-white bg-gray-700">
       </div>
@@ -46,44 +56,78 @@ export function initializeSearchConditions() {
     console.log(`🔄 現在の条件数: ${conditionCount}`);
   }
 
-  // ✅ 検索条件追加
+  // ✅ 検索タイプ変更時の処理
+  function attachConditionListeners(id) {
+    const searchType = document.querySelector(`[data-condition-id="${id}"]`);
+    const queryContainer = document.getElementById(`query-container-${id}`);
+
+    if (!searchType || !queryContainer) {
+      console.warn(`⚠️ 検索タイプまたは検索フィールドコンテナが見つかりません。ID: ${id}`);
+      return;
+    }
+
+    searchType.addEventListener('change', () => {
+      if (searchType.value === 'year') {
+        queryContainer.innerHTML = `
+          <select name="search_values[]" class="condition-select block w-full px-4 py-2 border rounded-md text-white bg-gray-700">
+            <option value="">年代を選択</option>
+            ${Array.from({ length: 26 }, (_, i) => `<option value="${2000 + i}">${2000 + i}</option>`).join('')}
+          </select>
+        `;
+        console.log(`🟢 検索フィールド ${id} が年代選択に切り替わりました`);
+      } else {
+        queryContainer.innerHTML = `
+          <input type="text" name="search_values[]" placeholder="キーワードを入力"
+            class="condition-input block w-full px-4 py-2 border rounded-md text-white bg-gray-700">
+        `;
+        console.log(`🟢 検索フィールド ${id} がテキスト入力に戻りました`);
+      }
+    });
+  }
+
+// ✅ 検索条件追加 (重複イベントを防止)
+if (!addConditionBtn.dataset.listenerAdded) {
   addConditionBtn.addEventListener('click', () => {
     if (searchConditionsContainer.querySelectorAll('.search-condition').length < MAX_CONDITIONS) {
       conditionId += 1;
       searchConditionsContainer.insertAdjacentHTML('beforeend', conditionTemplate(conditionId));
+      attachConditionListeners(conditionId);
       updateButtonStates();
       console.log(`🟢 検索条件${conditionId}が追加されました`);
     }
   });
+  addConditionBtn.dataset.listenerAdded = 'true';
+}
 
-  // ✅ 検索条件削除
+// ✅ 検索条件削除 (重複イベントを防止)
+if (!removeConditionBtn.dataset.listenerAdded) {
   removeConditionBtn.addEventListener('click', () => {
     const conditions = searchConditionsContainer.querySelectorAll('.search-condition');
-    if (conditions.length >= 1) {
+    if (conditions.length > 1) {
       conditions[conditions.length - 1].remove();
       updateButtonStates();
       console.log('🗑️ 最後の検索条件が削除されました。');
     }
   });
+  removeConditionBtn.dataset.listenerAdded = 'true';
+}
 
-  // ✅ 検索バリデーション
-  searchForm.addEventListener('submit', (event) => {
-    const errors = [];
-
-    if (!initialSearchType.value.trim()) {
-      errors.push('⚠️ 検索タイプが選択されていません。');
-    }
-    if (!initialQuery.value.trim()) {
-      errors.push('⚠️ 検索キーワードが入力されていません。');
-    }
-
-    if (errors.length > 0) {
-      event.preventDefault();
-      alert(errors.join('\n'));
-      console.warn('❌ 検索バリデーションエラー:', errors);
-    }
+  // ✅ 初期条件にリスナーを適用
+  searchConditionsContainer.querySelectorAll('.search-condition').forEach((condition) => {
+    const id = condition.dataset.conditionId;
+    attachConditionListeners(id);
   });
 
-  // 初期状態を設定
+  // ✅ 初期状態を設定
   updateButtonStates();
 }
+
+// ✅ 初期化関数
+function initializeSpotifySearch() {
+  initializeSearchConditions();
+}
+
+// ✅ TurboとDOMContentLoadedで初期化
+document.addEventListener('turbo:load', initializeSpotifySearch);
+document.addEventListener('turbo:render', initializeSpotifySearch);
+document.addEventListener('DOMContentLoaded', initializeSpotifySearch);

--- a/app/javascript/controllers/spotify_search.js
+++ b/app/javascript/controllers/spotify_search.js
@@ -1,4 +1,4 @@
-// 🎯 検索条件の初期化と動的追加・削除
+// ✅ 検索条件の初期化と動的追加・削除
 export function initializeSearchConditions() {
   console.log('✅ 検索条件の初期化開始');
 
@@ -9,8 +9,8 @@ export function initializeSearchConditions() {
   const initialSearchType = document.getElementById('initial-search-type');
   const initialQuery = document.getElementById('initial-query');
 
-  let conditionId = 0; // 初期条件は非表示なので0から開始
-  const MAX_CONDITIONS = 3; // 初期条件 + 追加2つ
+  let conditionId = 0;
+  const MAX_CONDITIONS = 3;
 
   if (!searchConditionsContainer || !addConditionBtn || !removeConditionBtn || !searchForm || !initialSearchType || !initialQuery) {
     console.warn('⚠️ 検索条件関連の要素が見つかりません。');
@@ -22,17 +22,18 @@ export function initializeSearchConditions() {
     <div class="search-condition mt-4" data-condition-id="${id}">
       <div class="mb-4">
         <label class="block text-sm font-medium text-white mb-2">🔍 検索タイプ</label>
-        <select name="search_conditions[]" class="condition-select block w-full px-4 py-2 border border-gray-400 rounded-md text-white bg-gray-700">
+        <select name="search_conditions[]" class="condition-select block w-full px-4 py-2 border rounded-md text-white bg-gray-700">
           <option value="">検索タイプを選択</option>
           <option value="track">曲名</option>
           <option value="artist">アーティスト名</option>
           <option value="keyword">キーワード</option>
+          <option value="year">年代</option>
         </select>
       </div>
       <div class="mb-6">
         <label class="block text-sm font-medium text-white mb-2">📝 検索キーワード</label>
         <input type="text" name="search_values[]" placeholder="キーワードを入力"
-          class="condition-input block w-full px-4 py-2 border border-gray-400 rounded-md text-white bg-gray-700">
+          class="condition-input block w-full px-4 py-2 border rounded-md text-white bg-gray-700">
       </div>
     </div>
   `;
@@ -40,42 +41,35 @@ export function initializeSearchConditions() {
   // ✅ ボタン状態を更新
   function updateButtonStates() {
     const conditionCount = searchConditionsContainer.querySelectorAll('.search-condition').length;
-    addConditionBtn.disabled = conditionCount >= MAX_CONDITIONS; // 最大数
-    removeConditionBtn.disabled = conditionCount <= 1; // 最小数（1セット以上）
+    addConditionBtn.disabled = conditionCount >= MAX_CONDITIONS;
+    removeConditionBtn.disabled = conditionCount <= 1;
     console.log(`🔄 現在の条件数: ${conditionCount}`);
   }
 
   // ✅ 検索条件追加
-  if (!addConditionBtn.hasAttribute('data-listener')) {
-    addConditionBtn.addEventListener('click', () => {
-      if (searchConditionsContainer.querySelectorAll('.search-condition').length < MAX_CONDITIONS) {
-        conditionId += 1;
-        searchConditionsContainer.insertAdjacentHTML('beforeend', conditionTemplate(conditionId));
-        updateButtonStates();
-        console.log(`🟢 検索条件${conditionId}が追加されました`);
-      }
-    });
-    addConditionBtn.setAttribute('data-listener', 'true');
-  }
+  addConditionBtn.addEventListener('click', () => {
+    if (searchConditionsContainer.querySelectorAll('.search-condition').length < MAX_CONDITIONS) {
+      conditionId += 1;
+      searchConditionsContainer.insertAdjacentHTML('beforeend', conditionTemplate(conditionId));
+      updateButtonStates();
+      console.log(`🟢 検索条件${conditionId}が追加されました`);
+    }
+  });
 
   // ✅ 検索条件削除
-  if (!removeConditionBtn.hasAttribute('data-listener')) {
-    removeConditionBtn.addEventListener('click', () => {
-      const conditions = searchConditionsContainer.querySelectorAll('.search-condition');
-      if (conditions.length >= 1) {
-        conditions[conditions.length - 1].remove();
-        updateButtonStates();
-        console.log('🗑️ 最後の検索条件が削除されました。');
-      }
-    });
-    removeConditionBtn.setAttribute('data-listener', 'true');
-  }
+  removeConditionBtn.addEventListener('click', () => {
+    const conditions = searchConditionsContainer.querySelectorAll('.search-condition');
+    if (conditions.length >= 1) {
+      conditions[conditions.length - 1].remove();
+      updateButtonStates();
+      console.log('🗑️ 最後の検索条件が削除されました。');
+    }
+  });
 
   // ✅ 検索バリデーション
   searchForm.addEventListener('submit', (event) => {
     const errors = [];
 
-    // 初期条件のバリデーション
     if (!initialSearchType.value.trim()) {
       errors.push('⚠️ 検索タイプが選択されていません。');
     }
@@ -83,9 +77,8 @@ export function initializeSearchConditions() {
       errors.push('⚠️ 検索キーワードが入力されていません。');
     }
 
-    // エラー表示と送信ブロック
     if (errors.length > 0) {
-      event.preventDefault(); // ページ遷移をブロック
+      event.preventDefault();
       alert(errors.join('\n'));
       console.warn('❌ 検索バリデーションエラー:', errors);
     }
@@ -94,12 +87,3 @@ export function initializeSearchConditions() {
   // 初期状態を設定
   updateButtonStates();
 }
-
-// ✅ 初期化関数
-function initializeSpotifySearch() {
-  initializeSearchConditions();
-}
-
-// ✅ TurboとDOMContentLoadedで初期化
-document.addEventListener('turbo:load', initializeSpotifySearch);
-document.addEventListener('DOMContentLoaded', initializeSpotifySearch);

--- a/app/javascript/controllers/spotify_year_toggle.js
+++ b/app/javascript/controllers/spotify_year_toggle.js
@@ -1,0 +1,48 @@
+// ✅ 年代検索用フォームを動的にロード
+async function loadYearSearchTemplate() {
+    try {
+      const response = await fetch('/spotify/year_search_template', {
+        headers: { 'X-Requested-With': 'XMLHttpRequest' }
+      });
+  
+      if (!response.ok) {
+        throw new Error(`HTTPエラー! ステータス: ${response.status}`);
+      }
+  
+      const yearSearchHtml = await response.text();
+      const queryContainer = document.getElementById('initial-query-container');
+  
+      if (queryContainer) {
+        queryContainer.innerHTML = yearSearchHtml;
+        console.log('🟢 年代検索用フォームがロードされました');
+      } else {
+        console.warn('⚠️ initial-query-container が見つかりません。');
+      }
+    } catch (error) {
+      console.error('❌ 年代検索フォームのロードに失敗:', error);
+    }
+  }
+  
+  // ✅ 検索タイプ変更時の処理
+  export function initializeYearToggle() {
+    const searchType = document.getElementById('initial-search-type');
+    const queryContainer = document.getElementById('initial-query-container');
+  
+    if (!searchType || !queryContainer) {
+      console.warn('⚠️ 検索タイプまたは検索フィールドコンテナが見つかりません。');
+      return;
+    }
+  
+    searchType.addEventListener('change', async () => {
+      if (searchType.value === 'year') {
+        await loadYearSearchTemplate();
+      } else {
+        queryContainer.innerHTML = `
+          <input type="text" name="initial_query" id="initial-query" placeholder="キーワードを入力"
+            class="condition-input block w-full px-4 py-2 border rounded-md text-white bg-gray-700">
+        `;
+        console.log('🟢 検索フィールドがテキスト入力に戻りました');
+      }
+    });
+  }
+  

--- a/app/views/spotify/_search.html.erb
+++ b/app/views/spotify/_search.html.erb
@@ -13,12 +13,12 @@
         <div class="mb-4">
           <%= f.label :initial_search_type, "🔍 検索タイプ", class: "block text-sm font-medium text-white mb-2" %>
           <%= f.select :initial_search_type, 
-                [["曲名", "track"], ["アーティスト名", "artist"], ["キーワード", "keyword"]],
+                [["曲名", "track"], ["アーティスト名", "artist"], ["キーワード", "keyword"],["年代", "year"]],
                 { prompt: "検索タイプを選択" },
                 { id: "initial-search-type",
                   class: "condition-select block w-full px-4 py-2 border border-gray-400 rounded-md text-white bg-gray-700 focus:ring-blue-500 focus:border-blue-500" } %>
         </div>
-        <div class="mb-6">
+        <div class="mb-6" id="initial-query-container">
           <%= f.label :initial_query, "📝 検索キーワード", class: "block text-sm font-medium text-white mb-2" %>
           <%= f.text_field :initial_query, placeholder: "キーワードを入力", id: "initial-query", 
                 class: "condition-input block w-full px-4 py-2 border border-gray-400 rounded-md text-white bg-gray-700 placeholder-gray-400 focus:ring-blue-500 focus:border-blue-500" %>

--- a/app/views/spotify/_search.html.erb
+++ b/app/views/spotify/_search.html.erb
@@ -5,7 +5,7 @@
       <%= image_tag 'spotify.png', alt: 'Spotify Logo', class: 'inline h-6 w-6' %>
       Spotify 曲検索
     </div>
-    <p class="text-xl font-bold text-white text-center">検索条件は計３つまで増やせます</p>
+    <p class="text-xl font-bold text-white text-center">2つの条件を組み合わせて検索できます</p>
 
     <!-- 🔍 検索条件リスト -->
     <div id="search-conditions">

--- a/app/views/spotify/_year_search_template.html.erb
+++ b/app/views/spotify/_year_search_template.html.erb
@@ -1,0 +1,7 @@
+<select name="initial_query" id="initial-query" 
+        class="condition-select block w-full px-4 py-2 border rounded-md text-white bg-gray-700">
+  <option value="">年代を選択</option>
+  <% (1970..2025).each do |year| %>
+    <option value="<%= year %>"><%= year %></option>
+  <% end %>
+</select>

--- a/app/views/spotify/results.html.erb
+++ b/app/views/spotify/results.html.erb
@@ -50,6 +50,5 @@
 
 <!-- 🔄 検索フォーム -->
 <div class="mt-8 p-6 rounded-lg bg-gray-800 shadow-md">
-  <h3 class="text-xl font-bold text-white mb-4 text-center">🔄 再検索</h3>
   <%= render partial: 'spotify/search', locals: { custom_class: 'search-results-style' } %>
 </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -17,6 +17,7 @@ Rails.application.routes.draw do
   get "spotify/search", to: "spotify#search", as: :spotify_search
   get "spotify/results", to: "spotify#results", as: "spotify_results"
   post "spotify/select_tracks", to: "spotify#select_tracks", as: :select_tracks
+  get "spotify/year_search_template", to: "spotify#year_search_template"
 
   # Defines the root path route ("/")
   root "static_pages#top"


### PR DESCRIPTION
### 📋 **概要**
- Spotify検索機能において、検索条件として「年代(year)」を追加。
- 検索条件の追加・削除時に、条件が正しく個別に動作するよう修正。
- 入力内容がリセットされないように改善。

---

### 🔄 **変更内容**
1. **検索条件の「年代」対応**  
   - 検索タイプに「年代(year)」を追加。  
   - 年代を選択するとドロップダウンが表示され、2000年から2025年までの選択肢を提供。  
   
2. **動的追加・削除の改善**  
   - 検索条件ごとに`conditionId`を動的に管理。  
   - 検索条件が個別に追加・削除され、他の条件に影響を与えないよう修正。  

3. **入力値の保持**  
   - 検索条件を追加・削除しても、既存の検索条件の入力値がリセットされないよう対応。  

4. **JavaScriptのリファクタリング**  
   - イベントリスナーの重複を防止。  
   - 検索条件ごとに適切なリスナーを割り当て。  

---

### ✅ **動作確認方法**
1. Spotify検索ページを開く。  
2. 検索条件を追加し、タイプを「年代(year)」に切り替える。  
3. 他の検索条件を追加しても、それぞれが独立して動作することを確認。  
4. 検索条件を削除しても、他の条件が維持されることを確認。  
5. 検索ボタンを押して、正しい検索結果が表示されることを確認。
