### PR TITLE
1970年からの年代検索ができるようになりました

### DIFF
--- a/app/controllers/spotify_controller.rb
+++ b/app/controllers/spotify_controller.rb
@@ -72,15 +72,15 @@ class SpotifyController < ApplicationController
   def autocomplete
     query = params[:query]
     type = params[:type] || "track,artist"
-  
+
     return render json: [] if query.blank?
-  
+
     begin
       headers = {
         Authorization: "Bearer #{fetch_access_token}",
         "Accept-Language" => "ja"
       }
-  
+
       response = RestClient.get(
         "https://api.spotify.com/v1/search",
         {
@@ -92,9 +92,9 @@ class SpotifyController < ApplicationController
         }.merge(headers)
       )
       results = JSON.parse(response.body)
-  
+
       autocomplete_results = []
-  
+
       # 検索タイプに応じて結果を整形
       if type.include?("track") && results["tracks"] && results["tracks"]["items"]
         autocomplete_results += results["tracks"]["items"].map do |track|
@@ -106,7 +106,7 @@ class SpotifyController < ApplicationController
           }
         end
       end
-  
+
       if type.include?("artist") && results["artists"] && results["artists"]["items"]
         autocomplete_results += results["artists"]["items"].map do |artist|
           {
@@ -116,7 +116,7 @@ class SpotifyController < ApplicationController
           }
         end
       end
-  
+
       render json: autocomplete_results
     rescue RestClient::ExceptionWithResponse => e
       Rails.logger.error "🚨 Spotify Autocomplete API Error: #{e.response}"
@@ -181,7 +181,7 @@ class SpotifyController < ApplicationController
   # 🔄 アクセストークンを取得・更新
   def fetch_access_token
     token = ENV["SPOTIFY_ACCESS_TOKEN"]
-  
+
     if token.nil? || token_expired?
       # アクセストークンをリフレッシュ
       refresh_access_token
@@ -189,7 +189,7 @@ class SpotifyController < ApplicationController
       token
     end
   end
-  
+
   def refresh_access_token
     begin
       response = RestClient.post(

--- a/app/controllers/spotify_controller.rb
+++ b/app/controllers/spotify_controller.rb
@@ -72,15 +72,15 @@ class SpotifyController < ApplicationController
   def autocomplete
     query = params[:query]
     type = params[:type] || "track,artist"
-
+  
     return render json: [] if query.blank?
-
+  
     begin
       headers = {
         Authorization: "Bearer #{fetch_access_token}",
         "Accept-Language" => "ja"
       }
-
+  
       response = RestClient.get(
         "https://api.spotify.com/v1/search",
         {
@@ -92,9 +92,9 @@ class SpotifyController < ApplicationController
         }.merge(headers)
       )
       results = JSON.parse(response.body)
-
+  
       autocomplete_results = []
-
+  
       # 検索タイプに応じて結果を整形
       if type.include?("track") && results["tracks"] && results["tracks"]["items"]
         autocomplete_results += results["tracks"]["items"].map do |track|
@@ -106,7 +106,7 @@ class SpotifyController < ApplicationController
           }
         end
       end
-
+  
       if type.include?("artist") && results["artists"] && results["artists"]["items"]
         autocomplete_results += results["artists"]["items"].map do |artist|
           {
@@ -116,7 +116,7 @@ class SpotifyController < ApplicationController
           }
         end
       end
-
+  
       render json: autocomplete_results
     rescue RestClient::ExceptionWithResponse => e
       Rails.logger.error "🚨 Spotify Autocomplete API Error: #{e.response}"

--- a/app/javascript/controllers/spotify_input.js
+++ b/app/javascript/controllers/spotify_input.js
@@ -63,7 +63,7 @@ export function initializeSpotifyInput() {
       queryContainer.innerHTML = `
         <select name="search_values[]" id="initial-query" class="condition-select block w-full px-4 py-2 border rounded-md text-white bg-gray-700">
           <option value="">年代を選択</option>
-          ${Array.from({ length: 26 }, (_, i) => `<option value="${2000 + i}">${2000 + i}</option>`).join('')}
+          ${Array.from({ length: 26 }, (_, i) => `<option value="${1970 + i}">${1970 + i}</option>`).join('')}
         </select>
         <ul id="autoComplete_list"></ul>
       `;

--- a/app/javascript/controllers/spotify_search.js
+++ b/app/javascript/controllers/spotify_search.js
@@ -72,27 +72,42 @@ export function initializeSearchConditions() {
     removeConditionBtn.disabled = conditionCount <= 1;
   }
 
-  /** 🔄 検索タイプ変更時の処理 */
   function handleConditionTypeChange(event) {
-    if (event.target.classList.contains('select')) {
-      const container = event.target.closest('.search-condition');
-      const queryContainer = container.querySelector('[id^="query-container-"]');
-
+    console.log("🔧 検索タイプが変更されました:", event.target.value);
+  
+    if (event.target.classList.contains("select")) {
+      const container = event.target.closest(".search-condition");
+      console.log("🔍 検索条件コンテナ:", container);
+  
+      const queryContainer = container?.querySelector('[id^="query-container-"]');
+      console.log("📦 クエリコンテナ:", queryContainer);
+  
       if (!queryContainer) {
-        console.warn('⚠️ クエリコンテナが見つかりません:', container);
+        console.warn("⚠️ クエリコンテナが見つかりません:", container);
         return;
       }
-
-      if (event.target.value === 'year') {
+  
+      // 現在の入力値を保持
+      const currentValue = queryContainer.querySelector("input, select")?.value || "";
+  
+      if (event.target.value === "year") {
+        console.log("🗓️ 年代が選択されました。");
+        
+        // 1970年から現在の年までの選択肢を生成
+        const currentYear = new Date().getFullYear();
         queryContainer.innerHTML = `
           <select name="search_values[]" class="select select-bordered w-full px-4 py-2 rounded-md bg-gray-700 text-white">
             <option value="">年代を選択</option>
-            ${Array.from({ length: 26 }, (_, i) => `<option value="${2000 + i}">${2000 + i}</option>`).join('')}
+            ${Array.from({ length: currentYear - 1970 + 1 }, (_, i) => {
+              const year = 1970 + i;
+              return `<option value="${year}" ${year === parseInt(currentValue) ? "selected" : ""}>${year}</option>`;
+            }).join("")}
           </select>
         `;
       } else {
+        console.log("🔤 テキスト入力が選択されました。");
         queryContainer.innerHTML = `
-          <input type="text" name="search_values[]" placeholder="キーワードを入力" class="input input-bordered w-full px-4 py-2 rounded-md bg-gray-700 text-white">
+          <input type="text" name="search_values[]" value="${currentValue}" placeholder="キーワードを入力" class="input input-bordered w-full px-4 py-2 rounded-md bg-gray-700 text-white">
         `;
       }
     }

--- a/app/views/spotify/_year_search_template.html.erb
+++ b/app/views/spotify/_year_search_template.html.erb
@@ -1,7 +1,12 @@
-<select name="initial_query" id="initial-query" 
-        class="condition-select block w-full px-4 py-2 border rounded-md text-white bg-gray-700">
-  <option value="">年代を選択</option>
-  <% (1970..2025).each do |year| %>
-    <option value="<%= year %>"><%= year %></option>
+<div id="query-container-<%= id %>">
+  <% if params[:search_conditions]&.include?('year') %>
+    <select name="search_values[]" class="select select-bordered w-full px-4 py-2 rounded-md bg-gray-700 text-white">
+      <option value="">年代を選択</option>
+      <% (1970..2025).each do |year| %>
+        <option value="<%= year %>" <%= 'selected' if params[:search_values]&.include?(year.to_s) %>><%= year %></option>
+      <% end %>
+    </select>
+  <% else %>
+    <input type="text" name="search_values[]" value="<%= params[:search_values]&.first %>" placeholder="キーワードを入力" class="input input-bordered w-full px-4 py-2 rounded-md bg-gray-700 text-white">
   <% end %>
-</select>
+</div>


### PR DESCRIPTION
## 概要
- 検索条件の年代選択範囲を1970年から現在の年まで拡張しました。

## 変更内容
- **修正**: 検索条件で「年代」を選択した際、選択肢に1970年から現在の年までが表示されるよう修正。
  - 該当箇所: `spotify_year_toggle.js` 内の `handleConditionTypeChange` 関数を修正。
  - `Array.from` を利用して1970年から現在の年までの配列を生成する処理を追加。
