### PR TITLE
プライバシーポリシーの作成

### DIFF
--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -1,0 +1,10 @@
+class PagesController < ApplicationController
+  def privacy_policy
+  end
+
+  def contact
+  end
+
+  def terms
+  end
+end

--- a/app/views/pages/contact.html.erb
+++ b/app/views/pages/contact.html.erb
@@ -1,0 +1,10 @@
+<!-- お問い合わせページ -->
+<div class="flex flex-col justify-center items-center mt-6 mb-6 mx-72">
+  <h1 class="text-3xl font-bold text-accent text-center">お問い合わせ（仮ページ）</h1>
+</div>
+
+<div class="container mx-auto pt-3 px-12 py-24">
+  <div class="mb-6">
+    <p class="text-center text-gray-700">準備中です。</p>
+  </div>
+</div>

--- a/app/views/pages/privacy_policy.html.erb
+++ b/app/views/pages/privacy_policy.html.erb
@@ -6,56 +6,99 @@
     </div>
 
     <div class="container mx-auto pt-3 px-12 py-24">
-      <div class="mb-6">
-        <h2 class="mb-2 text-lg font-bold text-primary">お客様から取得する情報</h2>
-        <p class="mb-2 text-sm text-gray-700">当サービスは、お客様から以下の情報を取得します。</p>
-        <ul class="pl-8 list-disc text-sm leading-8 text-gray-700">
-          <li>氏名(ニックネームやペンネームも含む)</li>
-          <li>メールアドレス</li>
-          <li>写真</li>
-          <li>外部サービスでお客様が利用するID、その他外部サービスのプライバシー設定によりお客様が連携先に開示を認めた情報</li>
-          <li>Cookie(クッキー)を用いて生成された識別情報</li>
-          <li>当サービスのウェブサイトの滞在時間、入力履歴等の当社ウェブサイトにおけるお客様の行動履歴</li>
-          <li>当サービスの起動時間、入力履歴等の利用履歴</li>
-        </ul>
-      </div>
-
-      <div class="mb-6">
-        <h2 class="mb-2 text-lg font-bold text-primary">お客様の情報を利用する目的</h2>
-        <p class="mb-2 text-sm text-gray-700">当サービスは、お客様から取得した情報を、以下の目的のために利用します。</p>
-        <ul class="pl-8 list-disc text-sm leading-8 text-gray-700">
-          <li>当サービスに関する登録の受付、お客様の本人確認、認証のため</li>
-          <li>お客様の当サービスの利用履歴を管理するため</li>
-          <li>当サービスにおけるお客様の行動履歴を分析し、当サービスの維持改善に役立てるため</li>
-          <li>お客様からのお問い合わせに対応するため</li>
-          <li>規約や法令に違反する行為に対応するため</li>
-          <li>変更、提供中止、終了、契約解除をご連絡するため</li>
-          <li>当サービス規約の変更等を通知するため</li>
-          <li>以上の他、当サービスの提供、維持、保護及び改善のため</li>
-        </ul>
-      </div>
-
-      <div class="mb-6">
-        <h2 class="mb-2 text-lg font-bold text-primary">安全管理のために講じた措置</h2>
-        <p class="mb-2 text-sm leading-7 text-gray-700">当サービスが、お客様から取得した情報に関して安全管理のために講じた措置につきましては、お問い合わせ先にご連絡をいただきましたら、法令の定めに従い個別にご回答させていただきます。</p>
-      </div>
-
-      <div class="mb-6">
-        <h2 class="mb-2 text-lg font-bold text-primary">第三者提供</h2>
-        <p class="text-sm leading-7 text-gray-700">当サービスは、お客様から取得する情報のうち、個人データ（個人情報保護法第１６条第３項）に該当するものついては、あらかじめお客様の同意を得ずに、第三者（日本国外にある者を含みます。）に提供しません。</p>
-      </div>
-
-      <div class="mb-6">
-        <h2 class="mb-2 text-lg font-bold text-primary">アクセス解析ツール</h2>
-        <p class="text-sm leading-7 text-gray-700">当サービスは、お客様のアクセス解析のために、「Googleアナリティクス」を利用しています。</p>
-        <p class="text-sm leading-7 text-gray-700">Googleアナリティクスは、トラフィックデータの収集のためにCookieを使用しています。トラフィックデータは匿名で収集されており、個人を特定するものではありません。Cookieを無効にすれば、これらの情報の収集を拒否することができます。詳しくはお使いのブラウザの設定をご確認ください。</p>
-        <p class="mb-2 text-sm leading-7 text-gray-700">Googleアナリティクスについて、詳しくは以下からご確認ください。</p>
-        <%= link_to "Googleアナリティクス利用規約（外部サイト）", "https://marketingplatform.google.com/about/analytics/terms/jp/", target: "_blank", class: "text-accent hover:text-accent-focus" %>
+      <div class="mb-8">
+        <p class="text-sm leading-7 text-gray-700">
+          MySongJournal（以下「当サービス」）は、ユーザーの個人情報保護の重要性を認識し、個人情報を保護することが社会的責務であると考え、個人情報に関する法令を遵守し、当サービスで取扱う個人情報の取得、利用、管理を適正に行います。
+        </p>
       </div>
 
       <div class="mb-8">
-        <h2 class="mb-2 text-lg font-bold text-primary">プライバシーポリシーの変更</h2>
-        <p class="text-sm leading-7 text-gray-700">当サービスは、必要に応じて、このプライバシーポリシーの内容を変更します。この場合、変更後のプライバシーポリシーの施行時期と内容を適切な方法により周知または通知します。</p>
+        <h2 class="mb-4 text-lg font-bold text-primary">1. 個人情報の取得・利用</h2>
+        
+        <div class="mb-6">
+          <h3 class="mb-2 text-md font-semibold text-primary">1.1 取得する情報</h3>
+          <p class="mb-2 text-sm text-gray-700">当サービスは、以下の情報を取得します：</p>
+          <ul class="pl-8 list-disc text-sm leading-8 text-gray-700">
+            <li>氏名（ニックネームやペンネームを含む）</li>
+            <li>メールアドレス</li>
+            <li>プロフィール画像</li>
+            <li>Spotifyアカウント連携による情報（ユーザーID、プレイリスト情報等）</li>
+            <li>利用端末情報</li>
+            <li>Cookie（クッキー）を用いて生成された識別情報</li>
+            <li>当サービスの利用履歴（アクセスログ、検索履歴等）</li>
+          </ul>
+        </div>
+
+        <div class="mb-6">
+          <h3 class="mb-2 text-md font-semibold text-primary">1.2 利用目的</h3>
+          <p class="mb-2 text-sm text-gray-700">取得した情報は、以下の目的で利用します：</p>
+          <ul class="pl-8 list-disc text-sm leading-8 text-gray-700">
+            <li>ユーザー登録、本人確認、認証のため</li>
+            <li>サービスの提供、維持、改善のため</li>
+            <li>ユーザーサポート、お問い合わせ対応のため</li>
+            <li>利用規約等に違反する行為への対応のため</li>
+            <li>新機能、更新情報等の通知のため</li>
+            <li>利用状況の分析、統計データの作成のため</li>
+          </ul>
+        </div>
+      </div>
+
+      <div class="mb-8">
+        <h2 class="mb-4 text-lg font-bold text-primary">2. 個人情報の保管・管理</h2>
+        
+        <div class="mb-6">
+          <h3 class="mb-2 text-md font-semibold text-primary">2.1 安全管理措置</h3>
+          <p class="mb-2 text-sm text-gray-700">個人情報の漏洩、滅失、き損等を防止するため、以下の安全管理措置を講じています：</p>
+          <ul class="pl-8 list-disc text-sm leading-8 text-gray-700">
+            <li>SSL暗号化通信の使用</li>
+            <li>アクセス制御、認証機能の実装</li>
+            <li>定期的なセキュリティ更新の実施</li>
+            <li>個人情報取扱責任者の設置</li>
+          </ul>
+        </div>
+
+        <div class="mb-6">
+          <h3 class="mb-2 text-md font-semibold text-primary">2.2 保存期間</h3>
+          <p class="text-sm leading-7 text-gray-700">個人情報は、利用目的の達成に必要な期間に限り保持します。ただし、法令等により保存期間が定められている場合は、この限りではありません。</p>
+        </div>
+      </div>
+
+      <div class="mb-8">
+        <h2 class="mb-4 text-lg font-bold text-primary">3. 個人情報の第三者提供</h2>
+        <p class="text-sm leading-7 text-gray-700">当サービスは、以下のいずれかに該当する場合を除き、個人情報を第三者に提供しません：</p>
+        <ul class="pl-8 list-disc text-sm leading-8 text-gray-700">
+          <li>ユーザーの同意がある場合</li>
+          <li>法令に基づく場合</li>
+          <li>人の生命、身体または財産の保護のために必要がある場合</li>
+          <li>公衆衛生の向上または児童の健全な育成の推進のために特に必要がある場合</li>
+        </ul>
+      </div>
+
+      <div class="mb-8">
+        <h2 class="mb-4 text-lg font-bold text-primary">4. ユーザーの権利</h2>
+        <p class="mb-2 text-sm text-gray-700">ユーザーには以下の権利があります：</p>
+        <ul class="pl-8 list-disc text-sm leading-8 text-gray-700">
+          <li>個人情報の開示請求</li>
+          <li>個人情報の訂正・削除の請求</li>
+          <li>個人情報の利用停止の請求</li>
+          <li>個人情報の第三者提供の停止の請求</li>
+        </ul>
+        <p class="mt-4 text-sm leading-7 text-gray-700">これらの権利行使を希望される場合は、<%= link_to "お問い合わせ", contact_path, class: "text-accent hover:text-accent-focus" %>からご連絡ください。</p>
+      </div>
+
+      <div class="mb-8">
+        <h2 class="mb-4 text-lg font-bold text-primary">5. Cookieの使用</h2>
+        <p class="text-sm leading-7 text-gray-700">当サービスでは、ユーザー体験の向上やサービスの利用状況の分析のためにCookieを使用しています。ブラウザの設定でCookieを無効にすることも可能ですが、その場合、一部の機能が利用できなくなる可能性があります。</p>
+      </div>
+
+      <div class="mb-8">
+        <h2 class="mb-4 text-lg font-bold text-primary">6. 法令遵守・見直し</h2>
+        <p class="text-sm leading-7 text-gray-700">本プライバシーポリシーは、日本の個人情報保護法及び関連法令を遵守しています。また、法令改正や社会状況の変化に応じて、適宜見直しを行います。重要な変更がある場合は、当サービス上で通知します。</p>
+      </div>
+
+      <div class="mb-8">
+        <h2 class="mb-4 text-lg font-bold text-primary">7. お問い合わせ</h2>
+        <p class="text-sm leading-7 text-gray-700">本プライバシーポリシーに関するお問い合わせは、<%= link_to "お問い合わせフォーム", contact_path, class: "text-accent hover:text-accent-focus" %>よりご連絡ください。</p>
       </div>
 
       <div class="flex justify-end">

--- a/app/views/pages/privacy_policy.html.erb
+++ b/app/views/pages/privacy_policy.html.erb
@@ -1,0 +1,66 @@
+<!-- プライバシーポリシーページ -->
+<div class="min-h-screen bg-white py-10 px-4 sm:px-6 lg:px-8">
+  <div class="max-w-3xl mx-auto">
+    <div class="flex flex-col justify-center items-center mt-6 mb-6 mx-72">
+      <h1 class="text-3xl font-bold text-accent text-center"><%= t('.title') %></h1>
+    </div>
+
+    <div class="container mx-auto pt-3 px-12 py-24">
+      <div class="mb-6">
+        <h2 class="mb-2 text-lg font-bold text-primary">お客様から取得する情報</h2>
+        <p class="mb-2 text-sm text-gray-700">当サービスは、お客様から以下の情報を取得します。</p>
+        <ul class="pl-8 list-disc text-sm leading-8 text-gray-700">
+          <li>氏名(ニックネームやペンネームも含む)</li>
+          <li>メールアドレス</li>
+          <li>写真</li>
+          <li>外部サービスでお客様が利用するID、その他外部サービスのプライバシー設定によりお客様が連携先に開示を認めた情報</li>
+          <li>Cookie(クッキー)を用いて生成された識別情報</li>
+          <li>当サービスのウェブサイトの滞在時間、入力履歴等の当社ウェブサイトにおけるお客様の行動履歴</li>
+          <li>当サービスの起動時間、入力履歴等の利用履歴</li>
+        </ul>
+      </div>
+
+      <div class="mb-6">
+        <h2 class="mb-2 text-lg font-bold text-primary">お客様の情報を利用する目的</h2>
+        <p class="mb-2 text-sm text-gray-700">当サービスは、お客様から取得した情報を、以下の目的のために利用します。</p>
+        <ul class="pl-8 list-disc text-sm leading-8 text-gray-700">
+          <li>当サービスに関する登録の受付、お客様の本人確認、認証のため</li>
+          <li>お客様の当サービスの利用履歴を管理するため</li>
+          <li>当サービスにおけるお客様の行動履歴を分析し、当サービスの維持改善に役立てるため</li>
+          <li>お客様からのお問い合わせに対応するため</li>
+          <li>規約や法令に違反する行為に対応するため</li>
+          <li>変更、提供中止、終了、契約解除をご連絡するため</li>
+          <li>当サービス規約の変更等を通知するため</li>
+          <li>以上の他、当サービスの提供、維持、保護及び改善のため</li>
+        </ul>
+      </div>
+
+      <div class="mb-6">
+        <h2 class="mb-2 text-lg font-bold text-primary">安全管理のために講じた措置</h2>
+        <p class="mb-2 text-sm leading-7 text-gray-700">当サービスが、お客様から取得した情報に関して安全管理のために講じた措置につきましては、お問い合わせ先にご連絡をいただきましたら、法令の定めに従い個別にご回答させていただきます。</p>
+      </div>
+
+      <div class="mb-6">
+        <h2 class="mb-2 text-lg font-bold text-primary">第三者提供</h2>
+        <p class="text-sm leading-7 text-gray-700">当サービスは、お客様から取得する情報のうち、個人データ（個人情報保護法第１６条第３項）に該当するものついては、あらかじめお客様の同意を得ずに、第三者（日本国外にある者を含みます。）に提供しません。</p>
+      </div>
+
+      <div class="mb-6">
+        <h2 class="mb-2 text-lg font-bold text-primary">アクセス解析ツール</h2>
+        <p class="text-sm leading-7 text-gray-700">当サービスは、お客様のアクセス解析のために、「Googleアナリティクス」を利用しています。</p>
+        <p class="text-sm leading-7 text-gray-700">Googleアナリティクスは、トラフィックデータの収集のためにCookieを使用しています。トラフィックデータは匿名で収集されており、個人を特定するものではありません。Cookieを無効にすれば、これらの情報の収集を拒否することができます。詳しくはお使いのブラウザの設定をご確認ください。</p>
+        <p class="mb-2 text-sm leading-7 text-gray-700">Googleアナリティクスについて、詳しくは以下からご確認ください。</p>
+        <%= link_to "Googleアナリティクス利用規約（外部サイト）", "https://marketingplatform.google.com/about/analytics/terms/jp/", target: "_blank", class: "text-accent hover:text-accent-focus" %>
+      </div>
+
+      <div class="mb-8">
+        <h2 class="mb-2 text-lg font-bold text-primary">プライバシーポリシーの変更</h2>
+        <p class="text-sm leading-7 text-gray-700">当サービスは、必要に応じて、このプライバシーポリシーの内容を変更します。この場合、変更後のプライバシーポリシーの施行時期と内容を適切な方法により周知または通知します。</p>
+      </div>
+
+      <div class="flex justify-end">
+        <p class="text-sm text-gray-700"><%= t('.date_of_enactment') %></p>
+      </div>
+    </div>
+  </div>
+</div>

--- a/app/views/pages/terms.html.erb
+++ b/app/views/pages/terms.html.erb
@@ -1,0 +1,14 @@
+<!-- 利用規約ページ -->
+<div class="flex flex-col justify-center items-center mt-6 mb-6 mx-72">
+  <h1 class="text-3xl font-bold text-accent text-center">利用規約（仮ページ）</h1>
+</div>
+
+<div class="container mx-auto pt-3 px-12 py-24">
+  <div class="mb-6">
+    <p class="text-center text-gray-700">準備中です。</p>
+  </div>
+</div>
+
+<div class="flex justify-end">
+  <p class="text-sm text-gray-700">2025年1月14日 制定</p>
+</div>

--- a/app/views/shared/_footer_links.html.erb
+++ b/app/views/shared/_footer_links.html.erb
@@ -1,5 +1,5 @@
 <div class="mt-4 flex justify-center space-x-6">
-  <a href="#" class="text-center text-gray-600 font-bold">お問い合わせ</a>
-  <a href="#" class="text-center text-gray-600 font-bold">プライバシーポリシー</a>
-  <a href="#" class="text-center text-gray-600 font-bold">利用規約</a>
+  <%= link_to "お問い合わせ", contact_path, class: "text-center text-gray-600 font-bold" %>
+  <%= link_to "プライバシーポリシー", privacy_policy_path, class: "text-center text-gray-600 font-bold" %>
+  <%= link_to "利用規約", terms_path, class: "text-center text-gray-600 font-bold" %>
 </div>

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -1,0 +1,11 @@
+ja:
+  pages:
+    privacy_policy:
+      title: "プライバシーポリシー"
+      date_of_enactment: "2025年1月14日 制定"
+    contact:
+      title: "お問い合わせ"
+      date_of_update: "2025年1月14日 更新"
+    terms:
+      title: "利用規約"
+      date_of_enactment: "2025年1月14日 制定"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,24 +1,31 @@
 Rails.application.routes.draw do
   get "others_journal/index"
   devise_for :users
+  
   # Define your application routes per the DSL in https://guides.rubyonrails.org/routing.html
 
   # Reveal health status on /up that returns 200 if the app boots with no exceptions, otherwise 500.
-  # Can be used by load balancers and uptime monitors to verify that the app is live.
   get "up" => "rails/health#show", as: :rails_health_check
-  resources :journals
 
+  # 日記関連のルート
+  resources :journals
+  
   require "sidekiq/web"
   mount Sidekiq::Web => "/sidekiq"
 
-  # Render dynamic PWA files from app/views/pwa/*
   get "service-worker" => "rails/pwa#service_worker", as: :pwa_service_worker
   get "manifest" => "rails/pwa#manifest", as: :pwa_manifest
 
-  get "spotify/search", to: "spotify#search", as: :spotify_search
-  get "spotify/results", to: "spotify#results", as: "spotify_results"
+  # Spotify関連のルート
+  get "/spotify/search", to: "spotify#search", as: :spotify_search
+  get "/spotify/results", to: "spotify#results", as: "spotify_results"
   post "spotify/select_tracks", to: "spotify#select_tracks", as: :select_tracks
   get "spotify/autocomplete", to: "spotify#autocomplete"
+
+  # 静的ページのルート
+  get "/privacy_policy", to: "pages#privacy_policy"
+  get "/contact", to: "pages#contact"
+  get "/terms", to: "pages#terms"
 
   # Defines the root path route ("/")
   root "static_pages#top"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,7 +1,7 @@
 Rails.application.routes.draw do
   get "others_journal/index"
   devise_for :users
-  
+
   # Define your application routes per the DSL in https://guides.rubyonrails.org/routing.html
 
   # Reveal health status on /up that returns 200 if the app boots with no exceptions, otherwise 500.
@@ -9,7 +9,7 @@ Rails.application.routes.draw do
 
   # 日記関連のルート
   resources :journals
-  
+
   require "sidekiq/web"
   mount Sidekiq::Web => "/sidekiq"
 


### PR DESCRIPTION
## 概要
- プライバシーポリシー画面の新規作成
- ユーザーに対するデータ利用に関する情報を明示するためのUI追加

## 変更内容
- **新規追加**:
  - プライバシーポリシー画面 (`app/views/static_pages/privacy_policy.html.erb`)
  - プライバシーポリシーのルートを追加 (`config/routes.rb`)
- **修正**:
  - フッターにプライバシーポリシーリンクを追加 (`app/views/layouts/_footer.html.erb`)
- **デザイン調整**:
  - プライバシーポリシーページのスタイルを Tailwind CSS で統一

## 動作確認方法
1. **プライバシーポリシー画面の確認**
   - [x] サイトフッターの「プライバシーポリシー」リンクをクリックし、正しいページに遷移することを確認
   - [x] プライバシーポリシーの文言が正しく表示されていることを確認
2. **レスポンシブ対応の確認**
   - [x] モバイル・タブレット・デスクトップでデザインが崩れていないことを確認
3. **ルート設定の確認**
   - [x] `/privacy_policy` に直接アクセスしてプライバシーポリシーページが表示されることを確認

## 関連Issue
- #149 

## スクリーンショット
![image](https://github.com/user-attachments/assets/77158cfa-395f-4909-9a3c-fc6a7cfe6076)

