### PR TITLE
Fix/timeline

### DIFF
--- a/app/controllers/journals_controller.rb
+++ b/app/controllers/journals_controller.rb
@@ -103,8 +103,11 @@ class JournalsController < ApplicationController
 
   # 削除処理
   def destroy
+    @journal = current_user.journals.find(params[:id])
     @journal.destroy
-    redirect_to journals_path, notice: "日記が削除されました."
+    flash[:notice] = "日記を削除しました"
+    # リファラー（前のページ）が存在する場合はそこにリダイレクト
+    redirect_to request.referer.presence || journals_path
   end
 
   private
@@ -118,7 +121,19 @@ class JournalsController < ApplicationController
   end
 
   def store_location
-    session[:return_to] = request.fullpath
+    return unless request.referer
+
+    case request.referer
+    when /journals$/          # index
+      session[:return_to] = journals_path
+    when /timeline$/         # timeline
+      session[:return_to] = timeline_journals_path
+    when /mypages\/\d+$/    # mypage（数字のIDを含むパターンに修正）
+      session[:return_to] = mypage_path
+    else
+      session[:return_to] = journals_path
+    end
+    Rails.logger.info "📍 Stored return location: #{session[:return_to]} from referer: #{request.referer}"
   end
 
   def return_path

--- a/app/controllers/journals_controller.rb
+++ b/app/controllers/journals_controller.rb
@@ -4,7 +4,7 @@ class JournalsController < ApplicationController
   before_action :set_journal_for_show, only: [ :show ]  # showアクション用
   before_action :store_location, only: [ :index, :timeline ]
   before_action :authorize_journal, only: [ :edit, :update, :destroy ]
-  before_action :store_edit_source, only: [:edit]
+  before_action :store_edit_source, only: [ :edit ]
 
   # 一覧表示
   def index
@@ -99,7 +99,7 @@ class JournalsController < ApplicationController
   def update
     @journal = current_user.journals.find(params[:id])
     Rails.logger.info "🔄 Update action called with edit_source: #{session[:edit_source]}"
-    
+
     if @journal.update(journal_params)
       flash[:notice] = "日記を更新しました"
       redirect_path = get_redirect_path
@@ -116,16 +116,16 @@ class JournalsController < ApplicationController
     @journal = current_user.journals.find(params[:id])
     @journal.destroy
     flash[:notice] = "日記を削除しました"
-    
+
     # リファラーに基づいて適切なページにリダイレクト
-    redirect_path = if request.referer&.include?('mypage')
+    redirect_path = if request.referer&.include?("mypage")
                      mypage_path
-                   elsif request.referer&.include?('timeline')
+    elsif request.referer&.include?("timeline")
                      timeline_journals_path
-                   else
+    else
                      journals_path
-                   end
-    
+    end
+
     Rails.logger.info "🗑️ Redirecting after delete to: #{redirect_path} from referer: #{request.referer}"
     redirect_to redirect_path
   end
@@ -174,7 +174,7 @@ class JournalsController < ApplicationController
 
   def store_edit_source
     return unless request.referer
-    
+
     # リファラーのURLをセッションに保存
     session[:previous_url] = request.referer
     Rails.logger.info "💾 Stored previous URL: #{session[:previous_url]}"
@@ -183,10 +183,10 @@ class JournalsController < ApplicationController
   def get_redirect_path
     previous_url = session.delete(:previous_url)
     Rails.logger.info "🔍 Previous URL for redirect: #{previous_url}"
-    
-    if previous_url&.include?('mypage')
+
+    if previous_url&.include?("mypage")
       mypage_path
-    elsif previous_url&.include?('timeline')
+    elsif previous_url&.include?("timeline")
       timeline_journals_path
     else
       journals_path

--- a/app/controllers/mypages_controller.rb
+++ b/app/controllers/mypages_controller.rb
@@ -4,7 +4,7 @@ class MypagesController < ApplicationController
 
   def show
     @user = current_user
-  
+
     # タブに応じて表示する投稿を切り替え
     if params[:tab] == "liked_posts"
       @liked_journals = current_user.liked_journals
@@ -20,7 +20,7 @@ class MypagesController < ApplicationController
                              .per(3)
       @liked_journals = []  # 空の配列を設定
     end
-  
+
     respond_to do |format|
       format.html
       format.turbo_stream do
@@ -34,7 +34,7 @@ class MypagesController < ApplicationController
       end
     end
   end
-  
+
   def edit
     @user = current_user
     @profile_form = @user.profile || @user.build_profile

--- a/app/controllers/mypages_controller.rb
+++ b/app/controllers/mypages_controller.rb
@@ -4,22 +4,23 @@ class MypagesController < ApplicationController
 
   def show
     @user = current_user
-
+  
     # タブに応じて表示する投稿を切り替え
     if params[:tab] == "liked_posts"
       @liked_journals = current_user.liked_journals
-                                  .includes(:user)
-                                  .order(created_at: :desc)
-                                  .page(params[:page])
-                                  .per(3)
+                                    .includes(:user)
+                                    .order(created_at: :desc)
+                                    .page(params[:page])
+                                    .per(3)
     else
       @journals = current_user.journals
                              .includes(:user)
                              .order(created_at: :desc)
                              .page(params[:page])
                              .per(3)
+      @liked_journals = []  # 空の配列を設定
     end
-
+  
     respond_to do |format|
       format.html
       format.turbo_stream do
@@ -33,7 +34,7 @@ class MypagesController < ApplicationController
       end
     end
   end
-
+  
   def edit
     @user = current_user
     @profile_form = @user.profile || @user.build_profile

--- a/app/views/journals/_journal_card.html.erb
+++ b/app/views/journals/_journal_card.html.erb
@@ -40,13 +40,13 @@
     <div class="flex gap-2">
       <% if user_signed_in? %>
         <% if journal.user == current_user %>
-          <%= link_to '詳細', journal_path(journal), 
+          <%= link_to '詳細', journal_path(journal), data: { turbo: false },
               class: "flex-1 text-center py-2 px-4 min-w-[80px] bg-gray-500 text-white text-sm rounded hover:bg-gray-600" %>
-          <%= link_to "編集", edit_journal_path(journal), 
+          <%= link_to "編集", edit_journal_path(journal), data: { turbo: false },
               class: "flex-1 text-center py-2 px-4 min-w-[80px] bg-yellow-500 text-white text-sm rounded hover:bg-yellow-600" %>
           <%= button_to "削除", journal_path(journal),
               method: :delete,
-              data: { confirm: "本当に削除しますか？" },
+              data: { turbo: false, confirm: "本当に削除しますか？" },
               class: "flex-1 text-center py-2 px-4 min-w-[80px] bg-red-500 text-white text-sm rounded hover:bg-red-600" %>
         <% else %>
           <%= link_to '詳細', journal_path(journal), 

--- a/app/views/journals/edit.html.erb
+++ b/app/views/journals/edit.html.erb
@@ -67,7 +67,6 @@
               <%= image_tag 'spotify_logo.png', alt: 'Spotifyロゴ', class: 'h-6 w-auto' %>
               <span class="text-sm text-blue-500 underline">Spotifyで聴く</span>
             </a>
-            <span class="text-xs text-gray-600 ml-2">Spotify提供</span>
           </div>
         </div>
       <% end %>


### PR DESCRIPTION
## 概要
- 日記の削除・編集後のページ遷移を改善
- Turboの無効化による安定性の向上

## 変更内容
- **機能追加**: 
  - 削除後のリダイレクト先を元のページ（mypage/timeline/index）に応じて動的に設定
  - 編集元ページの記憶機能を実装
- **バグ修正**:
  - 日記の削除・編集後もユーザーが元いたページに留まるように修正
- **UI改善**:
  - 特定のリンクでTurboを無効化し、ページ遷移の安定性を向上

## 動作確認方法
1. **マイページからの操作確認**
   - [ ] 日記を削除し、マイページに留まることを確認
   - [ ] 日記を編集し、保存後マイページに戻ることを確認

2. **タイムラインからの操作確認**
   - [ ] 日記を削除し、タイムラインに留まることを確認
   - [ ] 日記を編集し、保存後タイムラインに戻ることを確認

3. **一覧ページからの操作確認**
   - [ ] 日記を削除し、一覧ページに留まることを確認
   - [ ] 日記を編集し、保存後一覧ページに戻ることを確認

## 関連Issue
- close #[Issue番号]

## 技術的な変更点
- `store_edit_source`メソッドの追加によるリファラー情報の保持
- `get_redirect_path`メソッドによる適切なリダイレクト先の決定
- Turbo関連の`data-turbo="false"`属性の追加

## 備考
- ログ出力を追加し、デバッグ時の追跡を容易化
- リファクタリングの余地: セッション管理の最適化