### PR TITLE
フォロー・フォロワー機能の実装

### DIFF
--- a/app/controllers/follows_controller.rb
+++ b/app/controllers/follows_controller.rb
@@ -1,0 +1,38 @@
+class FollowsController < ApplicationController
+  before_action :authenticate_user!
+  before_action :set_user
+
+  def create
+    current_user.follow(@user)
+    render_updates
+  end
+
+  def destroy
+    current_user.unfollow(@user)
+    render_updates
+  end
+
+  private
+
+  def set_user
+    @user = User.find(params[:id])
+  end
+
+  def render_updates
+    # 複数のTurbo Streamを配列で返す
+    render turbo_stream: [
+      # フォローボタンの更新
+      turbo_stream.update_all(
+        ".follow-button-#{@user.id}",
+        partial: "follows/button_content",
+        locals: { user: @user }
+      ),
+      # フォロー/フォロワー数の更新
+      turbo_stream.update(
+        "follow-stats",
+        partial: "follows/stats",
+        locals: { user: current_user }
+      )
+    ]
+  end
+end

--- a/app/models/follow.rb
+++ b/app/models/follow.rb
@@ -1,0 +1,16 @@
+class Follow < ApplicationRecord
+  belongs_to :follower, class_name: "User"
+  belongs_to :followed, class_name: "User"
+
+  validates :follower_id, presence: true
+  validates :followed_id, presence: true
+  validate :cannot_follow_self
+
+  private
+
+  def cannot_follow_self
+    if follower_id == followed_id
+      errors.add(:base, "自分自身をフォローすることはできません")
+    end
+  end
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -12,4 +12,25 @@ class User < ApplicationRecord
   has_many :liked_journals, through: :likes, source: :journal
   has_many :favorites, dependent: :destroy
   has_many :favorited_journals, through: :favorites, source: :journal
+
+  # フォローしている関連
+  has_many :active_follows, class_name: "Follow", foreign_key: "follower_id", dependent: :destroy
+  has_many :following, through: :active_follows, source: :followed
+
+  # フォローされている関連
+  has_many :passive_follows, class_name: "Follow", foreign_key: "followed_id", dependent: :destroy
+  has_many :followers, through: :passive_follows, source: :follower
+
+  # フォロー関連のメソッド
+  def follow(other_user)
+    following << other_user unless self == other_user
+  end
+
+  def unfollow(other_user)
+    following.delete(other_user)
+  end
+
+  def following?(other_user)
+    following.include?(other_user)
+  end
 end

--- a/app/views/follows/_button.html.erb
+++ b/app/views/follows/_button.html.erb
@@ -1,0 +1,3 @@
+<div id="follow-button-<%= user.id %>" class="follow-button-<%= user.id %> transform-none">
+  <%= render 'follows/button_content', user: user %>
+</div> 

--- a/app/views/follows/_button_content.html.erb
+++ b/app/views/follows/_button_content.html.erb
@@ -1,0 +1,15 @@
+<% if user_signed_in? && current_user != user %>
+  <% if current_user.following?(user) %>
+    <%= button_to unfollow_user_path(user), 
+        method: :delete,
+        class: "px-2 py-1 bg-gray-500 text-white rounded-full text-xs hover:bg-gray-600 transform-none" do %>
+      <i class="fas fa-user-minus mr-1"></i>フォロー中
+    <% end %>
+  <% else %>
+    <%= button_to follow_user_path(user), 
+        method: :post,
+        class: "px-2 py-1 bg-blue-500 text-white rounded-full text-xs hover:bg-blue-600 transform-none" do %>
+      <i class="fas fa-user-plus mr-1"></i>フォロー
+    <% end %>
+  <% end %>
+<% end %> 

--- a/app/views/follows/_stats.html.erb
+++ b/app/views/follows/_stats.html.erb
@@ -1,0 +1,10 @@
+<div class="flex space-x-4 text-sm text-gray-600 ml-2">
+  <div class="flex flex-col items-center">
+    <span class="font-bold"><%= user.following.count %></span>
+    <span>フォロー</span>
+  </div>
+  <div class="flex flex-col items-center">
+    <span class="font-bold"><%= user.followers.count %></span>
+    <span>フォロワー</span>
+  </div>
+</div> 

--- a/app/views/journals/_journal_card.html.erb
+++ b/app/views/journals/_journal_card.html.erb
@@ -18,11 +18,7 @@
       <div class="flex items-center gap-2 text-sm text-gray-600">
         <span>by <%= journal.user.name %></span>
         <% if user_signed_in? && journal.user != current_user %>
-          <%= button_to "#", 
-              method: :post,
-              class: "px-2 py-1 bg-blue-500 text-white rounded-full text-xs hover:bg-blue-600" do %>
-            <i class="fas fa-user-plus mr-1"></i>フォロー
-          <% end %>
+          <%= render 'follows/button', user: journal.user %>
         <% end %>
       </div>
     </div>

--- a/app/views/journals/timeline.html.erb
+++ b/app/views/journals/timeline.html.erb
@@ -6,12 +6,12 @@
         <h1 class="text-2xl font-bold">タイムライン</h1>
         <p class="text-sm text-gray-600 mt-1">*フォローボタンを押すと日記を書いたユーザーをフォローできます。</p>
       </div>
-       <%= form_with url: journals_path, method: :get, local: true, class: "flex items-center space-x-2 text-white", id: "emotion-filter-form" do |f| %>
-        <%= f.select :emotion,
+       <%= form_with url: timeline_journals_path, method: :get, local: true, class: "flex items-center space-x-2 text-white", id: "emotion-filter-form" do |f| %>
+             <%= f.select :emotion,
             Journal.emotions.keys.map { |key| [key.humanize, key] },
-            { include_blank: "すべて", selected: params[:emotion] },
+            { include_blank: "すべての感情", selected: params[:emotion] },
             { 
-              class: "px-4 py-2 border rounded-md bg-customred",
+              class: "px-4 py-2 border rounded-md bg-customred text-white",
               onchange: "this.form.requestSubmit()"
             } 
         %>

--- a/app/views/mypages/show.html.erb
+++ b/app/views/mypages/show.html.erb
@@ -24,15 +24,8 @@
                 <%= link_to "", current_user.x_link, class: "fa-brands fa-x-twitter text-gray-400 text-2xl" %>
               </div>
               <!-- フォロー/フォロワー -->
-              <div class="flex space-x-4 text-sm text-gray-600 ml-2">
-                <div class="flex flex-col items-center">
-                  <span class="font-bold">0</span>
-                  <span>フォロー</span>
-                </div>
-                <div class="flex flex-col items-center">
-                  <span class="font-bold">0</span>
-                  <span>フォロワー</span>
-                </div>
+              <div id="follow-stats">
+                <%= render 'follows/stats', user: current_user %>
               </div>
             </div>
           </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -37,4 +37,11 @@ Rails.application.routes.draw do
 
   # マイページ関連のルート
   resource :mypage, only: [ :show, :edit, :update ]
+
+  resources :users do
+    member do
+      post "follow", to: "follows#create"
+      delete "unfollow", to: "follows#destroy"
+    end
+  end
 end

--- a/db/migrate/20250130150154_create_follows.rb
+++ b/db/migrate/20250130150154_create_follows.rb
@@ -1,0 +1,13 @@
+class CreateFollows < ActiveRecord::Migration[7.2]
+  def change
+    create_table :follows do |t|
+      t.integer :follower_id, null: false
+      t.integer :followed_id, null: false
+
+      t.timestamps
+    end
+    add_index :follows, :follower_id
+    add_index :follows, :followed_id
+    add_index :follows, [ :follower_id, :followed_id ], unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2025_01_30_143406) do
+ActiveRecord::Schema[7.2].define(version: 2025_01_30_150154) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -50,6 +50,16 @@ ActiveRecord::Schema[7.2].define(version: 2025_01_30_143406) do
     t.index ["journal_id"], name: "index_favorites_on_journal_id"
     t.index ["user_id", "journal_id"], name: "index_favorites_on_user_id_and_journal_id", unique: true
     t.index ["user_id"], name: "index_favorites_on_user_id"
+  end
+
+  create_table "follows", force: :cascade do |t|
+    t.integer "follower_id", null: false
+    t.integer "followed_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["followed_id"], name: "index_follows_on_followed_id"
+    t.index ["follower_id", "followed_id"], name: "index_follows_on_follower_id_and_followed_id", unique: true
+    t.index ["follower_id"], name: "index_follows_on_follower_id"
   end
 
   create_table "journals", force: :cascade do |t|

--- a/test/fixtures/follows.yml
+++ b/test/fixtures/follows.yml
@@ -1,0 +1,9 @@
+# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+one:
+  follower_id: 1
+  followed_id: 1
+
+two:
+  follower_id: 1
+  followed_id: 1

--- a/test/models/follow_test.rb
+++ b/test/models/follow_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class FollowTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
## 概要
フォロー・フォロワー機能の実装とマイページでのフォロー数表示機能の追加

## 変更内容
### モデル関連
- **新規追加**: Followモデルの作成
  - `follower_id`と`followed_id`のカラムを持つ中間テーブル
  - 自分自身へのフォロー防止のバリデーション
- **追加**: Userモデルにフォロー関連のアソシエーションとメソッドを追加
  - `following`と`followers`の関連付け
  - `follow`/`unfollow`/`following?`メソッドの実装

### コントローラー関連
- **新規追加**: FollowsController
  - フォロー作成（`create`）アクション
  - フォロー解除（`destroy`）アクション
  - Turbo Streamsによる非同期更新

### ビュー関連
- **新規追加**: フォローボタンのパーシャル
  - `_button.html.erb`: ボタンのコンテナ
  - `_button_content.html.erb`: ボタンの中身
  - `_stats.html.erb`: フォロー/フォロワー数表示
- **修正**: ジャーナルカードのフォローボタン表示
- **修正**: マイページのフォロー/フォロワー数表示

### ルーティング
- **追加**: フォロー関連のルート
  - `follow`アクション（POST）
  - `unfollow`アクション（DELETE）

## 動作確認方法
1. **フォロー機能の基本動作**
   - [ ] 他ユーザーの投稿に対してフォローができる
   - [ ] フォロー済みのユーザーに対して解除ができる
   - [ ] 自分の投稿にはフォローボタンが表示されない

2. **非同期処理の確認**
   - [ ] フォローボタンを押してもページ遷移が発生しない
   - [ ] 同じユーザーの全ての投稿のフォローボタンが同時に更新される
   - [ ] フォロー/フォロワー数が即座に更新される

3. **マイページでの表示**
   - [ ] フォロー数とフォロワー数が正しく表示される
   - [ ] フォロー/フォロー解除時に数値が更新される

4. **バリデーション**
   - [ ] 自分自身をフォローできない
   - [ ] 同じユーザーを重複してフォローできない

## 関連Issue
- close #226 

## スクリーンショット
- フォローボタンのデザイン（未フォロー / フォロー中）
- マイページのフォロー/フォロワー数表示
- タイムラインでのフォローボタン表示

## 技術的な変更点
- Turbo Streamsによる非同期更新の実装
- フォローの重複を防ぐためのユニークインデックス設定
- ボタンのデザイン統一のためのTailwind CSSクラス調整

## 備考
- データベースのマイグレーションが必要です
- 本番環境でのTurboの動作確認をお願いします