### PR TITLE
Feat/follow page

### DIFF
--- a/app/assets/stylesheets/application.tailwind.css
+++ b/app/assets/stylesheets/application.tailwind.css
@@ -15,4 +15,15 @@
   .tab-link.active {
     @apply border-primary text-primary border-b-2;
   }
+
+  .tab {
+    cursor: pointer;
+    padding: 10px;
+    border-bottom: 2px solid transparent;
+  }
+
+  .tab-active {
+    border-bottom: 2px solid blue;
+    color: blue;
+  }
 }

--- a/app/controllers/follows_controller.rb
+++ b/app/controllers/follows_controller.rb
@@ -1,6 +1,6 @@
 class FollowsController < ApplicationController
   before_action :authenticate_user!
-  before_action :set_user
+  before_action :set_user, except: [:following, :followers]
 
   def create
     current_user.follow(@user)
@@ -10,6 +10,18 @@ class FollowsController < ApplicationController
   def destroy
     current_user.unfollow(@user)
     render_updates
+  end
+
+  def following
+    @user = User.find(params[:id])
+    @users = @user.following.page(params[:page]).per(20)
+    render 'follows/show'
+  end
+
+  def followers
+    @user = User.find(params[:id])
+    @users = @user.followers.page(params[:page]).per(20)
+    render 'follows/show'
   end
 
   private

--- a/app/controllers/follows_controller.rb
+++ b/app/controllers/follows_controller.rb
@@ -1,6 +1,6 @@
 class FollowsController < ApplicationController
   before_action :authenticate_user!
-  before_action :set_user, except: [:following, :followers]
+  before_action :set_user, except: [ :following, :followers ]
 
   def create
     current_user.follow(@user)
@@ -15,13 +15,13 @@ class FollowsController < ApplicationController
   def following
     @user = User.find(params[:id])
     @users = @user.following.page(params[:page]).per(20)
-    render 'follows/show'
+    render "follows/show"
   end
 
   def followers
     @user = User.find(params[:id])
     @users = @user.followers.page(params[:page]).per(20)
-    render 'follows/show'
+    render "follows/show"
   end
 
   private

--- a/app/controllers/journals_controller.rb
+++ b/app/controllers/journals_controller.rb
@@ -32,7 +32,9 @@ class JournalsController < ApplicationController
 
   # 詳細表示
   def show
-    # @journalは set_journal_for_show で設定済み
+    @journal = Journal.find(params[:id])
+    @user = @journal.user
+    @user_name = @user.name
   end
 
   # 新規作成フォーム表示

--- a/app/controllers/mypages_controller.rb
+++ b/app/controllers/mypages_controller.rb
@@ -9,7 +9,7 @@ class MypagesController < ApplicationController
     case params[:tab]
     when "liked_posts"
       @journals = []  # 自分の投稿は空配列に
-      @liked_journals = current_user.favorited_journals
+      @liked_journals = current_user.liked_journals
                                   .includes(:user)
                                   .order(created_at: :desc)
                                   .page(params[:page])

--- a/app/controllers/other_users_controller.rb
+++ b/app/controllers/other_users_controller.rb
@@ -1,7 +1,7 @@
 class OtherUsersController < ApplicationController
   def show
     @user = User.find(params[:id])
-    
+    @user_name = @user.name
     # 自分自身のページにアクセスしようとした場合、リダイレクト
     if @user == current_user
       redirect_to mypage_path

--- a/app/controllers/other_users_controller.rb
+++ b/app/controllers/other_users_controller.rb
@@ -1,0 +1,14 @@
+class OtherUsersController < ApplicationController
+  def show
+    @user = User.find(params[:id])
+    
+    # 自分自身のページにアクセスしようとした場合、リダイレクト
+    if @user == current_user
+      redirect_to mypage_path
+      return
+    end
+
+    @journals = @user.journals.order(created_at: :desc).page(params[:page]).per(3)
+    @liked_journals = @user.liked_journals.order(created_at: :desc).page(params[:page]).per(3)
+  end
+end

--- a/app/controllers/others_journal_controller.rb
+++ b/app/controllers/others_journal_controller.rb
@@ -1,4 +1,0 @@
-class OthersJournalController < ApplicationController
-  def index
-  end
-end

--- a/app/helpers/other_users_helper.rb
+++ b/app/helpers/other_users_helper.rb
@@ -1,0 +1,2 @@
+module OtherUsersHelper
+end

--- a/app/helpers/otherusers_helper.rb
+++ b/app/helpers/otherusers_helper.rb
@@ -1,0 +1,2 @@
+module OtherusersHelper
+end

--- a/app/javascript/controllers/application.js
+++ b/app/javascript/controllers/application.js
@@ -14,3 +14,13 @@ window.Stimulus = application
 
 // 📤 他のファイルで使用できるようにエクスポート
 export { application }
+
+document.addEventListener('turbo:load', function() {
+  const tabs = document.querySelectorAll('.tab');
+  tabs.forEach(tab => {
+    tab.addEventListener('click', function() {
+      document.querySelector('.tab-active').classList.remove('tab-active');
+      this.classList.add('tab-active');
+    });
+  });
+});

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -8,10 +8,10 @@ class User < ApplicationRecord
          :recoverable, :rememberable, :validatable
   # バリデーション
   validates :name, presence: true, length: { maximum: 50 }
-  has_many :likes
-  has_many :liked_journals, through: :likes, source: :journal
+  
+  # favorites の関連
   has_many :favorites, dependent: :destroy
-  has_many :favorited_journals, through: :favorites, source: :journal
+  has_many :liked_journals, through: :favorites, source: :journal
 
   # フォローしている関連
   has_many :active_follows, class_name: "Follow", foreign_key: "follower_id", dependent: :destroy

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -8,7 +8,7 @@ class User < ApplicationRecord
          :recoverable, :rememberable, :validatable
   # バリデーション
   validates :name, presence: true, length: { maximum: 50 }
-  
+
   # favorites の関連
   has_many :favorites, dependent: :destroy
   has_many :liked_journals, through: :favorites, source: :journal

--- a/app/views/follows/_stats.html.erb
+++ b/app/views/follows/_stats.html.erb
@@ -1,10 +1,11 @@
-<div class="flex space-x-4 text-sm text-gray-600 ml-2">
-  <div class="flex flex-col items-center">
-    <span class="font-bold"><%= user.following.count %></span>
-    <span>フォロー</span>
-  </div>
-  <div class="flex flex-col items-center">
-    <span class="font-bold"><%= user.followers.count %></span>
-    <span>フォロワー</span>
-  </div>
+<div class="flex space-x-4 text-base text-gray-600 ml-2">
+  <%= link_to following_user_path(user), class: "flex flex-col items-center hover:text-blue-500 transition-colors" do %>
+      <span class="text-lg">フォロー</span>
+    <span class="font-bold text-xl"><%= user.following.count %></span>
+  <% end %>
+  
+  <%= link_to followers_user_path(user), class: "flex flex-col items-center hover:text-blue-500 transition-colors" do %>
+   <span class="text-lg">フォロワー</span>
+    <span class="font-bold text-xl"><%= user.followers.count %></span>
+  <% end %>
 </div> 

--- a/app/views/follows/show.html.erb
+++ b/app/views/follows/show.html.erb
@@ -1,0 +1,53 @@
+<div class="min-h-screen bg-customblue text-black flex flex-col items-center pt-8 pb-8">
+  <div class="bg-white p-6 rounded shadow-md w-full max-w-2xl">
+    <div class="mb-6">
+      <h1 class="text-2xl font-bold">
+        <%= @user.name %>さんの<%= action_name == 'following' ? 'フォロー' : 'フォロワー' %>一覧
+      </h1>
+      <p class="text-sm text-gray-600 mt-1">
+        全<%= @users.total_count %>件
+      </p>
+    </div>
+
+    <div class="space-y-4">
+      <% @users.each do |user| %>
+        <%= link_to other_user_path(user), class: "block" do %>
+          <div class="flex items-center justify-between p-4 border rounded-lg hover:bg-gray-50">
+            <div class="flex items-center gap-4">
+              <!-- アイコン -->
+              <div class="w-12 h-12 rounded-full bg-gray-200 overflow-hidden">
+                <% if user.avatar&.attached? %>
+                  <%= image_tag user.avatar, class: "w-full h-full object-cover" %>
+                <% else %>
+                  <div class="w-full h-full flex items-center justify-center bg-gray-300">
+                    <%= image_tag 'profile_sample.png', class: "w-full h-full object-cover" %>
+                  </div>
+                <% end %>
+              </div>
+              
+              <!-- ユーザー情報 -->
+              <div>
+                <div class="font-bold"><%= user.name %></div>
+                <div class="text-sm text-gray-600">
+                  <%= user.bio.present? ? user.bio.truncate(50) : "自己紹介はまだありません" %>
+                </div>
+              </div>
+            </div>
+
+            <!-- フォローボタン（自分以外のユーザーの場合） -->
+            <% if user_signed_in? && current_user != user %>
+              <%= render 'follows/button', user: user %>
+            <% end %>
+          </div>
+        <% end %>
+      <% end %>
+    </div>
+
+    <!-- ページネーション -->
+    <div class="mt-6">
+      <%= paginate @users %>
+    </div>
+
+      <%= link_to 'マイページへ戻る', mypage_path, class: "text-blue-500 hover:underline text-sm font-medium" %>
+  </div>
+</div> 

--- a/app/views/journals/index.html.erb
+++ b/app/views/journals/index.html.erb
@@ -63,9 +63,10 @@
       <%= paginate @journals %>
     </div>
 
-    <!-- 日記作成ボタン -->
-    <div class="flex justify-center mt-6">
-      <%= link_to "新しい日記を作成", new_journal_path, class: "btn btn-primary w-full" %>
+     <!-- 新規作成ボタン -->
+    <div class="mt-6">
+      <%= link_to "新しい日記を作成", new_journal_path, 
+          class: "w-full block text-center py-3 bg-blue-500 text-white rounded-lg hover:bg-blue-600 transition-colors" %>
     </div>
   </div>
 </div>

--- a/app/views/journals/show.html.erb
+++ b/app/views/journals/show.html.erb
@@ -83,6 +83,10 @@
     <div class="text-center mt-6">
       <% if request.referer&.include?('timeline') %>
         <%= link_to "← タイムラインに戻る", timeline_journals_path, class: "text-blue-500 hover:underline text-sm font-medium" %>
+      <% elsif request.referer&.include?('mypage') %>
+        <%= link_to "← マイページに戻る", mypage_path, class: "text-blue-500 hover:underline text-sm font-medium" %>
+      <% elsif request.referer&.include?('other_user') %>
+        <%= link_to "← #{@user.name}さんのページに戻る", other_user_path(@user), class: "text-blue-500 hover:underline text-sm font-medium" %>
       <% else %>
         <%= link_to "← 日記一覧に戻る", journals_path, class: "text-blue-500 hover:underline text-sm font-medium" %>
       <% end %>

--- a/app/views/mypages/edit.html.erb
+++ b/app/views/mypages/edit.html.erb
@@ -1,11 +1,11 @@
-<div class="bg-white min-h-screen overflow-auto">
+<div class="bg-customblue min-h-screen overflow-auto">
   <div class="flex flex-col justify-center items-center mt-8 mb-8 mx-4 md:mx-24 lg:mx-72">
     <h1 class="text-3xl md:text-3xl lg:text-4xl font-bold text-accent text-center">
       <% content_for(:title, 'プロフィール編集') %>
     </h1>
   </div>
 
-  <div class="bg-gray-50 h-max m-5 p-10 flex flex-col">
+  <div class="h-max m-5 p-10 flex flex-col">
     <div class="flex flex-col justify-center items-center">
       <div class="bg-white w-[600px] p-8 rounded-lg shadow-sm">
         <%= form_with(model: @profile_form, url: mypage_path, local: true, data: {turbo: false}, method: :patch, multipart: true) do |f| %>

--- a/app/views/other_users/_posts_content.html.erb
+++ b/app/views/other_users/_posts_content.html.erb
@@ -1,33 +1,33 @@
 <% if params[:tab] == "liked_posts" %>
-  <% if @liked_journals.present? %>
+  <% if liked_journals.present? %>
     <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6">
-      <% @liked_journals.each do |journal| %>
+      <% liked_journals.each do |journal| %>
         <%= render 'journals/journal_card', journal: journal %>
       <% end %>
     </div>
     <%# ページネーション %>
     <div class="mt-8 flex justify-center">
-      <%= paginate @liked_journals, 
+      <%= paginate liked_journals, 
           window: 2,
           params: { tab: params[:tab] },
           data: { turbo_frame: "posts_content" } %>
     </div>
   <% else %>
-    <p class="text-center text-gray-500">他のユーザーがいいねした投稿はありません</p>
+    <p class="text-center text-gray-500">いいねした投稿はありません</p>
   <% end %>
 <% else %>
-  <% if @journals.present? %>
+  <% if @user.journals.present? %>
     <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6">
-      <% @journals.each do |journal| %>
+      <% @user.journals.each do |journal| %>
         <%= render 'journals/journal_card', journal: journal %>
       <% end %>
     </div>
-    <%# ページネーション %>
+   <%# ページネーション %>
     <div class="mt-8 flex justify-center">
-      <%= paginate @journals, 
-          window: 2,
-          params: { tab: params[:tab] },
-          data: { turbo_frame: "posts_content" } %>
+    <%= paginate @journals, 
+        window: 2,
+        params: { tab: params[:tab] },
+        data: { turbo_frame: "posts_content" } %>
     </div>
   <% else %>
     <p class="text-center text-gray-500">投稿はありません</p>

--- a/app/views/other_users/show.html.erb
+++ b/app/views/other_users/show.html.erb
@@ -21,9 +21,10 @@
           <div class="text-accent">
             <div class="flex items-center space-x-8">
               <p class="text-4xl font-bold"><%= @user.name %></p>
-            <% if @user.x_link.present? %>
-                <%= link_to "", @user.x_link, class: "fa-brands fa-x-twitter text-gray-400 text-4xl" %>
+           <% if @user.profile&.x_link.present? %>
+                <%= link_to "", @user.profile.x_link, class: "fa-brands fa-x-twitter text-gray-400 text-4xl" %>
             <% end %>
+
 
               <!-- フォロー/フォロワー -->
               <div id="follow-stats" class="flex items-center space-x-4">

--- a/app/views/other_users/show.html.erb
+++ b/app/views/other_users/show.html.erb
@@ -1,7 +1,7 @@
 <div class="bg-customblue min-h-screen overflow-auto">
   <div class="flex flex-col justify-center items-center mt-8 mb-8 mx-4 md:mx-24 lg:mx-72">
     <h1 class="text-3xl md:text-3xl lg:text-4xl font-bold text-accent text-center">
-      <% content_for(:title, 'マイページ') %>
+      <% content_for(:title, "#{@user.name}さんのページ") %>
     </h1>
   </div>
 
@@ -12,37 +12,36 @@
         <%# プロフィール上部：アバターと名前とXアイコン %>
         <div class="flex space-x-8 items-center mb-8 justify-center">
           <div class="text-center">
-            <% if current_user.avatar.attached? %>
-              <%= image_tag current_user.avatar, class: 'w-24 h-24 rounded-full object-cover border-2 border-primary shadow-sm' %>
+            <% if @user.avatar&.attached? %>
+              <%= image_tag @user.avatar, class: 'w-24 h-24 rounded-full object-cover border-2 border-primary shadow-sm' %>
             <% else %>
               <%= image_tag 'profile_sample.png', class: 'w-24 h-24 rounded-full object-cover border-2 border-primary shadow-sm' %>
             <% end %>
           </div>
           <div class="text-accent">
             <div class="flex items-center space-x-8">
-              <p class="text-4xl font-bold"><%= current_user.name %></p>
-              <%= link_to "", current_user.x_link, class: "fa-brands fa-x-twitter text-gray-400 text-4xl" %>
+              <p class="text-4xl font-bold"><%= @user.name %></p>
+            <% if @user.x_link.present? %>
+                <%= link_to "", @user.x_link, class: "fa-brands fa-x-twitter text-gray-400 text-4xl" %>
+            <% end %>
+
               <!-- フォロー/フォロワー -->
               <div id="follow-stats" class="flex items-center space-x-4">
-                <%= render 'follows/stats', user: current_user %>
+                <%= render 'follows/stats', user: @user %>
               </div>
+              <!-- フォローボタン -->
+              <% if user_signed_in? && current_user != @user %>
+                <%= render 'follows/button', user: @user %>
+              <% end %>
             </div>
           </div>
         </div>
         <%# プロフィール文 %>
         <div class="bg-gray-200 rounded-lg text-base mb-8 p-6 text-gray-700">
           <% if @user.bio.present? %>
-            <p class="text-center text-gray-400"><%= @user.bio %></p>
+            <p class="text-center text-gray-700"><%= @user.bio %></p>
           <% else %>
-            <p class="text-center text-gray-400">プロフィールを入力してください</p>
-          <% end %>
-        </div>
-        <%# プロフィール編集ボタン %>
-        <div class="flex justify-center">
-          <%= link_to edit_mypage_path, 
-              class: "flex items-center space-x-2 px-6 py-3 bg-gray-50 hover:bg-gray-100 rounded-lg text-primary transition duration-200" do %>
-            <span class="material-symbols-outlined text-base">edit</span>
-            <span class="text-base">プロフィール編集</span>
+            <p class="text-center text-gray-400">プロフィールはまだ設定されていません</p>
           <% end %>
         </div>
       </div>
@@ -57,10 +56,10 @@
         <nav class="flex space-x-8" aria-label="Tabs">
           <ul class="tab-list list-unstyled">
             <li class="tab <%= 'tab-active' if params[:tab] != 'liked_posts' %>">
-              <%= link_to "自分の投稿", mypage_path(tab: "my_posts"), data: { turbo_frame: "posts_content" } %>
+              <%= link_to "投稿一覧", other_user_path(@user, tab: "my_posts"), data: { turbo_frame: "posts_content" } %>
             </li>
             <li class="tab <%= 'tab-active' if params[:tab] == 'liked_posts' %>">
-              <%= link_to "いいねした投稿", mypage_path(tab: "liked_posts"), data: { turbo_frame: "posts_content" } %>
+              <%= link_to "いいねした投稿", other_user_path(@user, tab: "liked_posts"), data: { turbo_frame: "posts_content" } %>
             </li>
           </ul>
         </nav>
@@ -72,11 +71,6 @@
             journals: @journals,
             liked_journals: @liked_journals %>
       <% end %>
-         <!-- 新規作成ボタン -->
-    <div class="mt-6">
-      <%= link_to "新しい日記を作成", new_journal_path, 
-          class: "w-full block text-center py-3 bg-blue-500 text-white rounded-lg hover:bg-blue-600 transition-colors" %>
-    </div>
     </div>
   </div>
 </div>

--- a/app/views/others_journal/index.html.erb
+++ b/app/views/others_journal/index.html.erb
@@ -1,2 +1,0 @@
-<h1>Others#index</h1>
-<p>Find me in app/views/others/index.html.erb</p>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -43,10 +43,10 @@ Rails.application.routes.draw do
 
   resources :users do
     member do
-      post 'follow', to: 'follows#create'
-      delete 'unfollow', to: 'follows#destroy'
-      get 'following', to: 'follows#following'
-      get 'followers', to: 'follows#followers'
+      post "follow", to: "follows#create"
+      delete "unfollow", to: "follows#destroy"
+      get "following", to: "follows#following"
+      get "followers", to: "follows#followers"
     end
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,6 @@
 Rails.application.routes.draw do
+  get "other_users/show"
+  get "otherusers/show"
   get "others_journal/index"
   devise_for :users
 
@@ -37,11 +39,14 @@ Rails.application.routes.draw do
 
   # マイページ関連のルート
   resource :mypage, only: [ :show, :edit, :update ]
+  resources :other_users, only: [ :show ]
 
   resources :users do
     member do
-      post "follow", to: "follows#create"
-      delete "unfollow", to: "follows#destroy"
+      post 'follow', to: 'follows#create'
+      delete 'unfollow', to: 'follows#destroy'
+      get 'following', to: 'follows#following'
+      get 'followers', to: 'follows#followers'
     end
   end
 end

--- a/test/controllers/other_users_controller_test.rb
+++ b/test/controllers/other_users_controller_test.rb
@@ -1,0 +1,8 @@
+require "test_helper"
+
+class OtherUsersControllerTest < ActionDispatch::IntegrationTest
+  test "should get show" do
+    get other_users_show_url
+    assert_response :success
+  end
+end

--- a/test/controllers/other_users_controller_test.rb
+++ b/test/controllers/other_users_controller_test.rb
@@ -2,7 +2,8 @@ require "test_helper"
 
 class OtherUsersControllerTest < ActionDispatch::IntegrationTest
   test "should get show" do
-    get other_users_show_url
+    user = users(:one) # 適切なfixtureを使用
+    get other_user_path(user)
     assert_response :success
   end
 end

--- a/test/controllers/otherusers_controller_test.rb
+++ b/test/controllers/otherusers_controller_test.rb
@@ -1,0 +1,8 @@
+require "test_helper"
+
+class OtherusersControllerTest < ActionDispatch::IntegrationTest
+  test "should get show" do
+    get otherusers_show_url
+    assert_response :success
+  end
+end

--- a/test/controllers/otherusers_controller_test.rb
+++ b/test/controllers/otherusers_controller_test.rb
@@ -1,8 +1,0 @@
-require "test_helper"
-
-class OtherusersControllerTest < ActionDispatch::IntegrationTest
-  test "should get show" do
-    get otherusers_show_url
-    assert_response :success
-  end
-end


### PR DESCRIPTION
## 概要
- 他のユーザーのプロフィールページを実装し、自分自身のページにはアクセスできないようにしました。
- タブ切り替え機能を追加し、JavaScriptで動的に切り替えられるようにしました。
- フォロー・フォロワーの一覧ページを追加しました。

## 変更内容
- **新規追加**: `OtherUsersController` を作成し、他のユーザーのプロフィールページを表示。
- **修正**: 自分自身のページにアクセスしようとした場合、マイページにリダイレクトする処理を追加。
- **追加**: タブ切り替え機能を `application.js` に実装し、`turbo:load` イベントで動作するように設定。
- **スタイル**: タブのスタイルを `application.tailwind.css` に追加。
- **フォロー機能**: フォロー・フォロワーの一覧を表示するためのアクションを `FollowsController` に追加。

## 動作確認方法
1. **他のユーザーのページ**
   - [ ] 他のユーザーのプロフィールページにアクセスし、情報が正しく表示されることを確認。
   - [ ] 自分自身のページにアクセスしようとした場合、マイページにリダイレクトされることを確認。
2. **タブ切り替え**
   - [ ] タブをクリックして、投稿一覧といいねした投稿が正しく切り替わることを確認。
3. **フォロー・フォロワー一覧**
   - [ ] フォロー・フォロワーの一覧ページが正しく表示されることを確認。

## 関連Issue
- close #226 

## 参考資料
- [Qiita記事: Railsでのタブ切り替え実装](https://qiita.com/nakachan1994/items/566cfcb60376feb3fe8c)
- [【Rails7】メニューバーのタブの切り替えをJavaScritp + Stimulus で実装してみた]
(https://plog.kobacchi.com/rails7-navbar-menutab-change/)

