### PR TITLE
sessionデータが保存されなくなってしまっていたので戻しました

### DIFF
--- a/app/controllers/concerns/spotify/spotify_searchable.rb
+++ b/app/controllers/concerns/spotify/spotify_searchable.rb
@@ -3,6 +3,7 @@ module Spotify::SpotifySearchable
   include Spotify::SpotifyApiRequestable
 
   def search
+    save_journal_form
     # 検索時のみsessionを設定
     if params[:search_conditions].present? || params[:search_values].present?
       if request.referer&.include?("/edit")


### PR DESCRIPTION
## 概要
- save_journal_formの文字が消えていたことでセッションデータが保存されなくなってしまっていたので戻しました

## 変更内容
- **修正**: `save_journal_form`の1行を`app/controllers/concerns/spotify/spotify_searchable.rb`二追加


